### PR TITLE
Draft : homing_override_refacto

### DIFF
--- a/config/software/sensorless_homing/sensorless_BTT_TMC2240.cfg
+++ b/config/software/sensorless_homing/sensorless_BTT_TMC2240.cfg
@@ -21,6 +21,7 @@ endstop_pin: tmc2240_stepper_y:virtual_endstop
 diag0_pin: ^!Y_STOP
 driver_SGT: -64  # -64 is most sensitive value, 63 is least sensitive
 
+[include ../../macros/base/homing/sensorless_homing.cfg]
 
 ## PLEASE READ THE FOLLOWING:
 ## -64 is the most sensitive value, 63 is the least sensitive. Here we set a default

--- a/config/software/sensorless_homing/sensorless_MKS_TMC2240.cfg
+++ b/config/software/sensorless_homing/sensorless_MKS_TMC2240.cfg
@@ -21,6 +21,7 @@ endstop_pin: tmc2240_stepper_y:virtual_endstop
 diag1_pin: ^!Y_STOP
 driver_SGT: -64  # -64 is most sensitive value, 63 is least sensitive
 
+[include ../../macros/base/homing/sensorless_homing.cfg]
 
 ## PLEASE READ THE FOLLOWING:
 ## -64 is the most sensitive value, 63 is the least sensitive. Here we set a default

--- a/config/software/sensorless_homing/sensorless_TMC2209.cfg
+++ b/config/software/sensorless_homing/sensorless_TMC2209.cfg
@@ -21,6 +21,7 @@ endstop_pin: tmc2209_stepper_y:virtual_endstop
 diag_pin: ^Y_STOP
 driver_SGTHRS: 255
 
+[include ../../macros/base/homing/sensorless_homing.cfg]
 
 ## PLEASE READ THE FOLLOWING:
 ## 255 is the most sensitive value, 0 is the least sensitive. Here we set a default

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -22,8 +22,9 @@ gcode:
     {% set x_position_center = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
     {% set y_position_center = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
 
+    # Abort if homing_firt not properly set    
     {% if not _u_vars.homing_first|string|upper in 'XY' %}
-        { action_respond_error("Axis homing order not valid. Choose either X or Y first in the variables.cfg file!") }
+        { action_raise_error("Axis homing order not valid. Choose either X or Y first in the variables.cfg file!") }
     {% endif %}
 
     # reset parameters
@@ -60,17 +61,24 @@ gcode:
     {% if REQUEST_AXES['Z'] %}
         {% if ('z' in printer.toolhead.homed_axes) %}
             {% if (printer.toolhead.position.z < homing_zhop) %}
-                { action_respond_info("Z too low, performing ZHOP to rehome Z") if verbose }
+                {% if verbose %}
+                    RESPOND TYPE=command MSG="Z too low, performing ZHOP to rehome Z"
+                {% endif %}
                 G91
                 G0 Z{homing_zhop} F{z_drop_speed}
                 G90
             {% else %}
-                { action_respond_info("Z already safe, no ZHOP needed to rehome Z") if verbose }
+            {% if verbose %}
+                RESPOND TYPE=command MSG=Z already safe, no ZHOP needed to rehome Z"
             {% endif %}
         {% elif ('xy' in printer.toolhead.homed_axes) %}
-            { action_respond_info("X and Y already homed, no ZHOP needed to home Z") if verbose }
+            {% if verbose %}
+                RESPOND TYPE=command MSG=X and Y already homed, no ZHOP needed to home Z"
+            {% endif %}
         {% else %}
-            { action_respond_info("X and Y not homed, forcing full G28 to home Z properly") if verbose }
+            {% if verbose %}
+                RESPOND TYPE=command MSG="X and Y not homed, forcing full G28 to home Z properly"
+            {% endif %}
             SET_KINEMATIC_POSITION X=0 Y=0 Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
             {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
@@ -80,7 +88,10 @@ gcode:
 
     {% for axis in axes_order %}
         {% if REQUEST_AXES[axis] %}
-            { action_respond_info("Homing " ~ axis) if verbose }
+            {% if verbose %}
+                RESPOND TYPE=command MSG="Homing {axis}"
+            {% endif %}
+            
             _PRE_HOMEXY AXIS={axis}
             G28 {axis}0
             G0 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
@@ -91,7 +102,9 @@ gcode:
 
     # Home z
     {% if REQUEST_AXES['Z'] %}
-        { action_respond_info("Homing Z") if verbose }
+        {% if verbose %}
+            RESPOND TYPE=command MSG="Homing Z"
+        {% endif %}
 
         # If there is a virtual probe endstop (ie. TAP or inductive as virtual), we go to the center of the bed
         # If the Z endstop is not virtual, then we just move to it

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -33,7 +33,7 @@ gcode:
 
     # which axes have been requested for homing
     {% set REQUEST_AXES = {} %}
-    {% for axis in 'XYZ'}
+    {% for axis in 'XYZ' %}
         {% set _= REQUEST_AXES.update({axis : axis in params}) %}
     {% endfor %}
     # if no params set all axes
@@ -41,7 +41,7 @@ gcode:
         {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
     {% endif %}
 
-    {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
+    {% if probe_type_enabled in ["dockable","dockable_virtual"] %}
        _CHECK_PROBE action=query
        _PROBE_UNLOCK
        _ENTRY_POINT FUNCTION=homing_override
@@ -99,7 +99,7 @@ gcode:
         {% if _config.stepper_z.endstop_pin|lower == "probe:z_virtual_endstop" %}
             # If our virtual endstop is a dockable probe, we need to activate it first
             # If it's the voron tap, we put it to a safe temperature
-            {% if probe_type_enabled == "dockable_virtual" or probe_type_enabled == "vorontap" %}
+            {% if probe_type_enabled in ["dockable_virtual","vorontap"] %}
                 ACTIVATE_PROBE
             {% endif %}
 
@@ -129,21 +129,17 @@ gcode:
 
         # if voron tap, restore original temperature
         # if dockable probe as virtual endstop, then dock the probe
-        {% if probe_type_enabled == "vorontap" or probe_type_enabled == "dockable_virtual" %}
+        {% if probe_type_enabled in ["dockable_virtual","vorontap"] %}
             DEACTIVATE_PROBE
         {% endif %}
     {% endif %}
 
-    {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
-        _CHECK_PROBE action=query
-    {% endif %}
 
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}
-    
-     ACCEL_TO_DECEL={saved_decel}
 
-    {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
+    {% if probe_type_enabled  in ["dockable","dockable_virtual"] %}
+        _CHECK_PROBE action=query
         _EXIT_POINT FUNCTION=homing_override
     {% endif %}
 

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -41,8 +41,7 @@ gcode:
     {% if REQUEST_AXES.values()|sum in [0,3] %}
         {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
     {% endif %}
-    {% set axes_order = [axis for axis in axis_order if REQUEST_AXES[axis]]|join('') %}
-
+    
     {% if probe_type_enabled in ["dockable","dockable_virtual"] %}
        _CHECK_PROBE action=query
        _PROBE_UNLOCK

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -41,6 +41,7 @@ gcode:
     {% if REQUEST_AXES.values()|sum in [0,3] %}
         {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
     {% endif %}
+    {% set axes_order = [axis for axis in axis_order if REQUEST_AXES[axis]]|join('') %}
 
     {% if probe_type_enabled in ["dockable","dockable_virtual"] %}
        _CHECK_PROBE action=query
@@ -86,17 +87,14 @@ gcode:
         M400    # required for sensorless corexz, no impact on other kinematics
     {% endif %}
 
-    {% for axis in axes_order %}
-        {% if REQUEST_AXES[axis] %}
-            {% if verbose %}
-                RESPOND TYPE=command MSG="Homing {axis}"
-            {% endif %}
-            
-            _PRE_HOME_XY HOMED_AXIS={axis}
-            G28 {axis}0
-            G0 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
-            _POST_HOME_XY HOMED_AXIS={axis}
+    {% for axis in axes_order if REQUEST_AXES[axis] %}
+        {% if verbose %}
+            RESPOND TYPE=command MSG="Homing {axis}"
         {% endif %}
+        _PRE_HOME_XY HOMED_AXIS={axis} FIRST={loop.first|int}
+        G28 {axis}0
+        G0 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
+        _POST_HOME_XY HOMED_AXIS={axis} LAST={loop.last|int}
     {% endfor %}
 
 

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -75,13 +75,14 @@ gcode:
             {% if verbose %}
                 RESPOND TYPE=command MSG=X and Y already homed, no ZHOP needed to home Z"
             {% endif %}
-        {% else %}
+        {% elif REQUEST_AXES['X'] and REQUEST_AXES['Y'] %}
             {% if verbose %}
-                RESPOND TYPE=command MSG="X and Y not homed, forcing full G28 to home Z properly"
+                RESPOND TYPE=command MSG="X and Y requested, forcing full G28 to home Z properly"
             {% endif %}
             SET_KINEMATIC_POSITION X=0 Y=0 Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
-            {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
+        {% else %}
+            { action_raise_error("Must home XY axes first !") }
         {% endif %}
         M400    # required for sensorless corexz, no impact on other kinematics
     {% endif %}

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -92,10 +92,10 @@ gcode:
                 RESPOND TYPE=command MSG="Homing {axis}"
             {% endif %}
             
-            _PRE_HOME_XY AXIS={axis}
+            _PRE_HOME_XY HOMED_AXIS={axis}
             G28 {axis}0
             G0 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
-            _POST_HOME_XY AXIS={axis}
+            _POST_HOME_XY HOMED_AXIS={axis}
         {% endif %}
     {% endfor %}
 

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -37,7 +37,7 @@ gcode:
         {% set _= REQUEST_AXES.update({axis : axis in params}) %}
     {% endfor %}
     # if no params set all axes
-    {% if REQUEST_AXES.values|sum in [0,3] %}
+    {% if REQUEST_AXES.values()|sum in [0,3] %}
         {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
     {% endif %}
 

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -2,69 +2,52 @@
 [homing_override]
 axes: xyz
 gcode:
-    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
-    {% set kinematics = printer["configfile"].config["printer"]["kinematics"] %}
-    {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
-    {% set homing_zhop = printer["gcode_macro _USER_VARIABLES"].homing_zhop|float|abs %}
-    {% set homing_travel_speed = printer["gcode_macro _USER_VARIABLES"].homing_travel_speed * 60 %}
-    {% set homing_travel_accel = printer["gcode_macro _USER_VARIABLES"].homing_travel_accel %}
-    {% set sensorless_homing_enabled = printer["gcode_macro _USER_VARIABLES"].sensorless_homing_enabled %}
-    {% set sensorless_current_factor = printer["gcode_macro _USER_VARIABLES"].sensorless_current_factor / 100 %}
-    {% set x_driver = printer["gcode_macro _USER_VARIABLES"].x_driver %}
-    {% set y_driver = printer["gcode_macro _USER_VARIABLES"].y_driver %}
-    {% set z_driver = printer["gcode_macro _USER_VARIABLES"].z_driver %}
-    {% set z_drop_speed = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
-    {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
+    {% set _u_vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set _config = printer.configfile.config %}
+    {% set _settings = printer.configfile.settings %}
+    {% set verbose = _u_vars.verbose %}
+    {% set probe_type_enabled = _u_vars.probe_type_enabled %}
+    {% set homing_zhop = _u_vars.homing_zhop|float|abs %}
+    {% set homing_travel_speed = _u_vars.homing_travel_speed * 60 %}
+    {% set homing_travel_accel = _u_vars.homing_travel_accel %}
+    {% set z_drop_speed = _u_vars.z_drop_speed * 60 %}
+    {% set status_leds_enabled = _u_vars.status_leds_enabled %}
+    {% set bed_mesh_enabled = _u_vars.bed_mesh_enabled %}
 
-    {% set homing_first = printer["gcode_macro _USER_VARIABLES"].homing_first|string|upper %}
-    {% set x_homing_backoff, y_homing_backoff = printer["gcode_macro _USER_VARIABLES"].homing_backoff_distance_xy|map('float') %}
-
-    {% set x_position_endstop = printer["configfile"].config["stepper_x"]["position_endstop"]|float %}
-    {% set y_position_endstop = printer["configfile"].config["stepper_y"]["position_endstop"]|float %}
+    {% set axes_order = 'YX' if _u_vars.homing_first|string|upper == 'Y' else 'XY' %}
+    {% set homing_backoff = {'X': (_u_vars.homing_backoff_distance_xy|map('float'))[0], 
+                             'Y': (_u_vars.homing_backoff_distance_xy|map('float'))[1]} %}
+    {% set position_endstop = { 'X' : _config.stepper_x.position_endstop|float,
+                                'Y' : _config.stepper_y.position_endstop|float } %}
     {% set x_position_center = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
     {% set y_position_center = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
 
+    {% if not _u_vars.homing_first|string|upper in 'XY' %}
+        { action_respond_error("Axis homing order not valid. Choose either X or Y first in the variables.cfg file!") }
+    {% endif %}
 
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
         _CHECK_PROBE action=query
     {% endif %}
 
     # reset parameters
-    {% set X, Y, Z = False, False, False %}
-
     {% if status_leds_enabled %}
         STATUS_LEDS COLOR="HOMING"
     {% endif %}
 
     # which axes have been requested for homing
-    {% if not 'X' in params
-        and not 'Y' in params
-        and not 'Z' in params %}
-
-        {% set X, Y, Z = True, True, True %}
-
-    {% else %}
-        {% if 'X' in params %}
-            {% set X = True %}
-        {% endif %}
-
-        {% if 'Y' in params %}
-            {% set Y = True %}
-        {% endif %}
-
-        {% if 'Z' in params %}
-            {% set Z = True %}
-        {% endif %}
-
-        {% if 'X' in params
-          and 'Y' in params
-          and 'Z' in params %}
-            # reset homing state variables
-            # if homing all axes
-            _HOMING_VARIABLES reset=1
-         {% endif %}
-
+    {% set REQUEST_AXES = {} %}
+    {% for axis in 'XYZ'}
+        {% set _= REQUEST_AXES.update({axis : axis in params}) %}
+    {% endfor %}
+    {% if REQUEST_AXES.values|sum == 3 %}
+        # reset homing state variables
+        # if homing all axes
+        _HOMING_VARIABLES reset=1
+    {% endif %}
+    # if no params set all axes
+    {% if REQUEST_AXES.values|sum == 0 %}
+        {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
     {% endif %}
 
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
@@ -74,7 +57,7 @@ gcode:
     # Set the homing acceleration prior to any movement
     {% set saved_accel = printer.toolhead.max_accel %}
     {% set saved_decel = printer.toolhead.max_accel_to_decel %}
-    M204 S{homing_travel_accel}
+    SET_VELOCITY_LIMIT ACCEL={homing_travel_accel}
 
     {% if bed_mesh_enabled %}
         BED_MESH_CLEAR
@@ -82,7 +65,7 @@ gcode:
 
     G90
 
-    {% if Z %}
+    {% if REQUEST_AXES['Z'] %}
         {% if ('z' in printer.toolhead.homed_axes) %}
             {% if (printer.toolhead.position.z < homing_zhop) %}
                 {% if verbose %}
@@ -106,198 +89,33 @@ gcode:
             {% endif %}
             SET_KINEMATIC_POSITION X=0 Y=0 Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
-            {% if sensorless_homing_enabled and kinematics == "corexz" %}
-                # Wait for stallguard registers to clear
-                M400
-            {% endif %}
-            {% set X, Y, Z = True, True, True %}
+            {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
         {% endif %}
+        M400    # required for sensorless corexz, no impact on other kinematics
     {% endif %}
 
-    {% if homing_first == "X" %}
-        {% if X %} # Home x
+    {% for axis in axes_order %}
+        {% if REQUEST_AXES[axis] %}
             {% if verbose %}
-                { action_respond_info("Homing X") }
+                { action_respond_info("Homing " ~ axis) }
             {% endif %}
-            {% if sensorless_homing_enabled %}
-                {% if kinematics == "corexy" %}
-                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                    {% set new_current_x = sensorless_current_factor * old_current_x %}
-                    {% set new_current_y = sensorless_current_factor * old_current_y %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                    M400
-                {% elif kinematics == "corexz" %}
-                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                    {% set old_current_z = printer.configfile.config[z_driver ~ ' stepper_z'].run_current|float %}
-                    {% set new_current_x = sensorless_current_factor * old_current_x %}
-                    {% set new_current_z = sensorless_current_factor * old_current_z %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={new_current_z}
-                    M400
-                {% elif kinematics == "cartesian" %}
-                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                    {% set new_current_x = sensorless_current_factor * old_current_x %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                    M400
-                {% endif %}
-            {% endif %}
-            G28 X0
-            G1 X{x_position_endstop + x_homing_backoff} F{homing_travel_speed}
-            {% if sensorless_homing_enabled %}
-                {% if kinematics == "corexy" %}
-                    M400
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
-                {% elif kinematics == "corexz" %}
-                    M400
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={old_current_z}
-                {% elif kinematics == "cartesian" %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                {% endif %}
-            {% endif %}
+            _PRE_HOMEXY AXIS={axis}
+            G28 {axis}0
+            G1 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
+            _POST_HOMEXY AXIS={axis}
         {% endif %}
-        {% if Y %} # Home y
-            {% if verbose %}
-                { action_respond_info("Homing Y") }
-            {% endif %}
-            {% if sensorless_homing_enabled %}
-                {% if kinematics == "corexy" %}
-                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                    {% set new_current_x = sensorless_current_factor * old_current_x %}
-                    {% set new_current_y = sensorless_current_factor * old_current_y %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                    M400
-                {% elif kinematics == "corexz" %}
-                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                    {% set new_current_y = sensorless_current_factor * old_current_y %}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                    M400
-                {% elif kinematics == "cartesian" %}
-                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                    {% set new_current_y = sensorless_current_factor * old_current_y %}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                    M400
-                {% endif %}
-            {% endif %}
-            G28 Y0
-            G1 Y{y_position_endstop + y_homing_backoff} F{homing_travel_speed}
-            {% if sensorless_homing_enabled %}
-                {% if kinematics == "corexy" %}
-                    M400
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
-                {% elif kinematics == "corexz" %}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
-                {% elif kinematics == "cartesian" %}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
-                {% endif %}
-            {% endif %}
-        {% endif %}
-
-    {% elif homing_first == "Y" %}
-        {% if Y %} # Home y
-            {% if verbose %}
-                { action_respond_info("Homing Y") }
-            {% endif %}
-            {% if sensorless_homing_enabled %}
-                {% if kinematics == "corexy" %}
-                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                    {% set new_current_x = sensorless_current_factor * old_current_x %}
-                    {% set new_current_y = sensorless_current_factor * old_current_y %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                    M400
-                {% elif kinematics == "corexz" %}
-                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                    {% set new_current_y = sensorless_current_factor * old_current_y %}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                    M400
-                {% elif kinematics == "cartesian" %}
-                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                    {% set new_current_y = sensorless_current_factor * old_current_y %}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                    M400
-                {% endif %}
-            {% endif %}
-            G28 Y0
-            G1 Y{y_position_endstop + y_homing_backoff} F{homing_travel_speed}
-            {% if sensorless_homing_enabled %}
-                {% if kinematics == "corexy" %}
-                    M400
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
-                {% elif kinematics == "corexz" %}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
-                {% elif kinematics == "cartesian" %}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
-                {% endif %}
-            {% endif %}
-        {% endif %}
-        {% if X %} # Home x
-            {% if verbose %}
-                { action_respond_info("Homing X") }
-            {% endif %}
-            {% if sensorless_homing_enabled %}
-                {% if kinematics == "corexy" %}
-                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                    {% set new_current_x = sensorless_current_factor * old_current_x %}
-                    {% set new_current_y = sensorless_current_factor * old_current_y %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                    M400
-                {% elif kinematics == "corexz" %}
-                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                    {% set old_current_z = printer.configfile.config[z_driver ~ ' stepper_z'].run_current|float %}
-                    {% set new_current_x = sensorless_current_factor * old_current_x %}
-                    {% set new_current_z = sensorless_current_factor * old_current_z %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={new_current_z}
-                    M400
-                {% elif kinematics == "cartesian" %}
-                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                    {% set new_current_x = sensorless_current_factor * old_current_x %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                    M400
-                {% endif %}
-            {% endif %}
-            G28 X0
-            G1 X{x_position_endstop + x_homing_backoff} F{homing_travel_speed}
-            {% if sensorless_homing_enabled %}
-                {% if kinematics == "corexy" %}
-                    M400
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
-                {% elif kinematics == "corexz" %}
-                    M400
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={old_current_z}
-                {% elif kinematics == "cartesian" %}
-                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                {% endif %}
-            {% endif %}
-        {% endif %}
-
-    {% else %}
-        { action_respond_error("Axis homing order not valid. Choose either X or Y first in the variables.cfg file!") }
-    {% endif %}
+    {% endfor %}
 
 
     # Home z
-    {% if Z %}
+    {% if REQUEST_AXES['Z'] %}
         {% if verbose %}
             { action_respond_info("Homing Z") }
         {% endif %}
 
         # If there is a virtual probe endstop (ie. TAP or inductive as virtual), we go to the center of the bed
         # If the Z endstop is not virtual, then we just move to it
-        {% if printer["configfile"].config["stepper_z"]["endstop_pin"]|lower == "probe:z_virtual_endstop" %}
+        {% if _config.stepper_z.endstop_pin|lower == "probe:z_virtual_endstop" %}
             # If our virtual endstop is a dockable probe, we need to activate it first
             # If it's the voron tap, we put it to a safe temperature
             {% if probe_type_enabled == "dockable_virtual" or probe_type_enabled == "vorontap" %}
@@ -306,10 +124,10 @@ gcode:
 
             # If there is a bed_mesh enabled and a zero_reference_position set, we retrieve it to home on it
             # Else, we default to the center of the bed
-            {% if not bed_mesh_enabled or not printer["configfile"].config["bed_mesh"]["zero_reference_position"] %}
+            {% if not bed_mesh_enabled or not _config.bed_mesh.zero_reference_position %}
                 G0 X{x_position_center} Y{y_position_center} F{homing_travel_speed}
             {% else %}
-                {% set ZRPx, ZRPy = printer["configfile"].config["bed_mesh"]["zero_reference_position"].split(',')|map('trim')|map('float') %}
+                {% set ZRPx, ZRPy = _config.bed_mesh.zero_reference_position.split(',')|map('trim')|map('float') %}
                 G0 X{ZRPx} Y{ZRPy} F{homing_travel_speed}
             {% endif %}
 
@@ -321,9 +139,9 @@ gcode:
         G28 Z0
 
         G91
-        {% if printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == False %}
+        {% if _settings.stepper_z.homing_positive_dir == False %}
             G0 Z{homing_zhop} F{z_drop_speed} # small Z hop to avoid grinding the bed (as we should be close to Z0 right now)
-        {% elif printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == True %}
+        {% elif _settings.stepper_z.homing_positive_dir == True %}
             G0 Z-{homing_zhop} F{z_drop_speed} # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
         {% endif %}
         G90
@@ -340,7 +158,9 @@ gcode:
     {% endif %}
 
     # Reset acceleration values to what it was before
-    SET_VELOCITY_LIMIT ACCEL={saved_accel} ACCEL_TO_DECEL={saved_decel}
+    SET_VELOCITY_LIMIT ACCEL={saved_accel}
+    
+     ACCEL_TO_DECEL={saved_decel}
 
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
         _EXIT_POINT FUNCTION=homing_override
@@ -404,3 +224,9 @@ gcode:
     G0 X{z_endstop_x} Y{z_endstop_y} F{homing_travel_speed}
 
     RESTORE_GCODE_STATE NAME=goto_ZProbe
+
+[gcode_macro _PRE_HOME_XY]
+gcode:
+
+[gcode_macro _POST_HOME_XY]
+gcode:

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -92,10 +92,10 @@ gcode:
                 RESPOND TYPE=command MSG="Homing {axis}"
             {% endif %}
             
-            _PRE_HOMEXY AXIS={axis}
+            _PRE_HOME_XY AXIS={axis}
             G28 {axis}0
             G0 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
-            _POST_HOMEXY AXIS={axis}
+            _POST_HOME_XY AXIS={axis}
         {% endif %}
     {% endfor %}
 

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -49,7 +49,6 @@ gcode:
 
     # Set the homing acceleration prior to any movement
     {% set saved_accel = printer.toolhead.max_accel %}
-    {% set saved_decel = printer.toolhead.max_accel_to_decel %}
     SET_VELOCITY_LIMIT ACCEL={homing_travel_accel}
 
     {% if bed_mesh_enabled %}

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -15,8 +15,8 @@ gcode:
     {% set bed_mesh_enabled = _u_vars.bed_mesh_enabled %}
 
     {% set axes_order = 'YX' if _u_vars.homing_first|string|upper == 'Y' else 'XY' %}
-    {% set homing_backoff = {'X': (_u_vars.homing_backoff_distance_xy|map('float'))[0], 
-                             'Y': (_u_vars.homing_backoff_distance_xy|map('float'))[1]} %}
+    {% set homing_backoff = {'X': (_u_vars.homing_backoff_distance_xy|map('float')|list)[0], 
+                             'Y': (_u_vars.homing_backoff_distance_xy|map('float')|list)[1]} %}
     {% set position_endstop = { 'X' : _config.stepper_x.position_endstop|float,
                                 'Y' : _config.stepper_y.position_endstop|float } %}
     {% set x_position_center = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -83,7 +83,7 @@ gcode:
             { action_respond_info("Homing " ~ axis) if verbose }
             _PRE_HOMEXY AXIS={axis}
             G28 {axis}0
-            G1 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
+            G0 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
             _POST_HOMEXY AXIS={axis}
         {% endif %}
     {% endfor %}

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -26,10 +26,6 @@ gcode:
         { action_respond_error("Axis homing order not valid. Choose either X or Y first in the variables.cfg file!") }
     {% endif %}
 
-    {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
-        _CHECK_PROBE action=query
-    {% endif %}
-
     # reset parameters
     {% if status_leds_enabled %}
         STATUS_LEDS COLOR="HOMING"
@@ -40,17 +36,14 @@ gcode:
     {% for axis in 'XYZ'}
         {% set _= REQUEST_AXES.update({axis : axis in params}) %}
     {% endfor %}
-    {% if REQUEST_AXES.values|sum == 3 %}
-        # reset homing state variables
-        # if homing all axes
-        _HOMING_VARIABLES reset=1
-    {% endif %}
     # if no params set all axes
-    {% if REQUEST_AXES.values|sum == 0 %}
+    {% if REQUEST_AXES.values|sum in [0,3] %}
         {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
     {% endif %}
 
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
+       _CHECK_PROBE action=query
+       _PROBE_UNLOCK
        _ENTRY_POINT FUNCTION=homing_override
     {% endif %}
 
@@ -68,25 +61,17 @@ gcode:
     {% if REQUEST_AXES['Z'] %}
         {% if ('z' in printer.toolhead.homed_axes) %}
             {% if (printer.toolhead.position.z < homing_zhop) %}
-                {% if verbose %}
-                    { action_respond_info("Z too low, performing ZHOP to rehome Z") }
-                {% endif %}
+                { action_respond_info("Z too low, performing ZHOP to rehome Z") if verbose }
                 G91
                 G0 Z{homing_zhop} F{z_drop_speed}
                 G90
             {% else %}
-                {% if verbose %}
-                    { action_respond_info("Z already safe, no ZHOP needed to rehome Z") }
-                {% endif %}
+                { action_respond_info("Z already safe, no ZHOP needed to rehome Z") if verbose }
             {% endif %}
         {% elif ('xy' in printer.toolhead.homed_axes) %}
-            {% if verbose %}
-                { action_respond_info("X and Y already homed, no ZHOP needed to home Z") }
-            {% endif %}
+            { action_respond_info("X and Y already homed, no ZHOP needed to home Z") if verbose }
         {% else %}
-            {% if verbose %}
-                { action_respond_info("X and Y not homed, forcing full G28 to home Z properly") }
-            {% endif %}
+            { action_respond_info("X and Y not homed, forcing full G28 to home Z properly") if verbose }
             SET_KINEMATIC_POSITION X=0 Y=0 Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
             {% set REQUEST_AXES = {'X': True, 'Y': True, 'Z': True} %}
@@ -96,9 +81,7 @@ gcode:
 
     {% for axis in axes_order %}
         {% if REQUEST_AXES[axis] %}
-            {% if verbose %}
-                { action_respond_info("Homing " ~ axis) }
-            {% endif %}
+            { action_respond_info("Homing " ~ axis) if verbose }
             _PRE_HOMEXY AXIS={axis}
             G28 {axis}0
             G1 {axis}{position_endstop[axis] + homing_backoff[axis]} F{homing_travel_speed}
@@ -109,9 +92,7 @@ gcode:
 
     # Home z
     {% if REQUEST_AXES['Z'] %}
-        {% if verbose %}
-            { action_respond_info("Homing Z") }
-        {% endif %}
+        { action_respond_info("Homing Z") if verbose }
 
         # If there is a virtual probe endstop (ie. TAP or inductive as virtual), we go to the center of the bed
         # If the Z endstop is not virtual, then we just move to it
@@ -214,9 +195,7 @@ gcode:
 
 
     {% if avoid_dock == true  %}
-        {% if verbose %}
-            { action_respond_info("Avoiding probe dock to home Z...") }
-        {% endif %}
+        { action_respond_info("Avoiding probe dock to home Z...") if verbose }
         G0 Y{probe_dock_location_y - probe_dock_margin_y} F{homing_travel_speed}
         G0 X{z_endstop_x} F{homing_travel_speed}
     {% endif %}

--- a/macros/base/homing/sensorless_homing.cfg
+++ b/macros/base/homing/sensorless_homing.cfg
@@ -1,14 +1,14 @@
 [gcode_macro _PRE_HOME_XY]
 gcode:
-    _SET_DRIVERS MODE=HOME AXIS={params.AXIS}
+    _SET_DRIVERS MODE=HOME HOMED_AXIS={params.HOMED_AXIS}
 
 [gcode_macro _POST_HOME_XY]
 gcode:
-    _SET_DRIVERS MODE=RUN AXIS={params.AXIS}
+    _SET_DRIVERS MODE=RUN HOMED_AXIS={params.HOMED_AXIS}
 
 [gcode_macro _SET_DRIVERS]
 gcode:
-    {% set AXIS = params.AXIS %}
+    {% set HOMED_AXIS = params.HOMED_AXIS %}
     {% set MODE = params.MODE %}
 
     {% set kinematics = printer.configfile.config.printer.kinematics %}
@@ -18,14 +18,14 @@ gcode:
         _SET_TMC AXIS=X MODE={TYPE}
         _SET_TMC AXIS=Y MODE={TYPE}
     {% elif kinematics == "corexz" %}
-        {% if AXIS == 'X' %}
+        {% if HOMED_AXIS == 'X' %}
             _SET_TMC AXIS=X MODE={TYPE}
             _SET_TMC AXIS=Z MODE={TYPE}
-        {% elif AXIS == 'Y' %}
+        {% elif HOMED_AXIS == 'Y' %}
             _SET_TMC AXIS=Y MODE={TYPE}
         {% endif %}
     {% elif kinematics == "cartesian" %}
-        _SET_TMC AXIS={AXIS} MODE={TYPE}
+        _SET_TMC AXIS={HOMED_AXIS} MODE={TYPE}
     {% endif %}
     M400
 

--- a/macros/base/homing/sensorless_homing.cfg
+++ b/macros/base/homing/sensorless_homing.cfg
@@ -15,17 +15,17 @@ gcode:
 
     M400
     {% if kinematics == "corexy" %}
-        _SET_TMC AXIS=X MODE={TYPE}
-        _SET_TMC AXIS=Y MODE={TYPE}
+        _SET_TMC AXIS=X MODE={MODE}
+        _SET_TMC AXIS=Y MODE={MODE}
     {% elif kinematics == "corexz" %}
         {% if HOMED_AXIS == 'X' %}
-            _SET_TMC AXIS=X MODE={TYPE}
-            _SET_TMC AXIS=Z MODE={TYPE}
+            _SET_TMC AXIS=X MODE={MODE}
+            _SET_TMC AXIS=Z MODE={MODE}
         {% elif HOMED_AXIS == 'Y' %}
-            _SET_TMC AXIS=Y MODE={TYPE}
+            _SET_TMC AXIS=Y MODE={MODE}
         {% endif %}
     {% elif kinematics == "cartesian" %}
-        _SET_TMC AXIS={HOMED_AXIS} MODE={TYPE}
+        _SET_TMC AXIS={HOMED_AXIS} MODE={MODE}
     {% endif %}
     M400
 

--- a/macros/base/homing/sensorless_homing.cfg
+++ b/macros/base/homing/sensorless_homing.cfg
@@ -1,47 +1,44 @@
 [gcode_macro _PRE_HOME_XY]
 gcode:
-    _SET_DRIVERS MODE=HOME HOMED_AXIS={params.HOMED_AXIS}
+    _SET_DRIVERS MODE=HOME HOMED_AXIS={params.HOMED_AXIS} FIRST={params.FIRST} LAST=0
 
 [gcode_macro _POST_HOME_XY]
 gcode:
-    _SET_DRIVERS MODE=RUN HOMED_AXIS={params.HOMED_AXIS}
+    _SET_DRIVERS MODE=RUN HOMED_AXIS={params.HOMED_AXIS} LAST={params.LAST} FIRST=0
 
 [gcode_macro _SET_DRIVERS]
 gcode:
-    {% set HOMED_AXIS = params.HOMED_AXIS %}
-    {% set MODE = params.MODE %}
-
-    {% set kinematics = printer.configfile.config.printer.kinematics %}
-
-    M400
-    {% if kinematics == "corexy" %}
-        _SET_TMC AXIS=X MODE={MODE}
-        _SET_TMC AXIS=Y MODE={MODE}
-    {% elif kinematics == "corexz" %}
-        {% if HOMED_AXIS == 'X' %}
-            _SET_TMC AXIS=X MODE={MODE}
-            _SET_TMC AXIS=Z MODE={MODE}
-        {% elif HOMED_AXIS == 'Y' %}
-            _SET_TMC AXIS=Y MODE={MODE}
-        {% endif %}
-    {% elif kinematics == "cartesian" %}
-        _SET_TMC AXIS={HOMED_AXIS} MODE={MODE}
-    {% endif %}
-    M400
-
-[gcode_macro _SET_TMC]
-gcode:
+# Load variables
     {% set _u_vars = printer["gcode_macro _USER_VARIABLES"] %}
     
     {% set sensorless_current_factor = _u_vars.sensorless_current_factor|float / 100 %}
-    {% set AXIS = params.AXIS|upper %}
-    {% set MODE = params.MODE|upper %} #allowed values HOME | RUN
-    {% set driver = _u_vars[AXIS|lower ~ '_driver'] %}
-    
-    {% if AXIS in 'XYZ' %}
-        {% set current = printer.configfile.config[driver ~ ' stepper_' ~ AXIS|lower].run_current|float %}
-        {% if MODE== 'HOME' %}
+    {% set kinematics = printer.configfile.config.printer.kinematics %}
+    {% set HOMED_AXIS = params.HOMED_AXIS %}
+    {% set MODE = params.MODE %}
+    {% set _test = (params.FIRST|int and MODE='HOME') or (params.LAST|int and MODE='RUN') %}
+
+#  macro structure
+    {% macro set_tmc(axis) %}
+        {% set driver = _u_vars[axis ~ '_driver'] %}
+        {% set current = printer.configfile.config[driver ~ ' stepper_' ~ axis].run_current|float %}
+        {% if MODE == 'HOME' %}
             {% set current = current * sensorless_current_factor %}
         {% endif %}
-        SET_TMC_CURRENT STEPPER=stepper_{AXIS|lower} CURRENT={current}
+        SET_TMC_CURRENT STEPPER=stepper_{axis} CURRENT={current}
+    {% endmacro %}
+
+    M400
+    {% if kinematics == "corexy" and _test %}
+        { set_tmc('x') }
+        { set_tmc('y') }
+    {% elif kinematics == "corexz" %}
+        {% if HOMED_AXIS == 'X' %}
+            { set_tmc('x') }
+            { set_tmc('z') }
+        {% elif HOMED_AXIS == 'Y' %}
+            { set_tmc('y') }
+        {% endif %}
+    {% elif kinematics == "cartesian" %}
+        { set_tmc(HOMED_AXIS|lower) }
     {% endif %}
+    M400

--- a/macros/base/homing/sensorless_homing.cfg
+++ b/macros/base/homing/sensorless_homing.cfg
@@ -1,52 +1,46 @@
 [gcode_macro _PRE_HOME_XY]
 gcode:
-    _DO_SENSORLESS_STUFF TYPE=HOME AXIS={params.AXIS}
+    _SET_DRIVERS MODE=HOME AXIS={params.AXIS}
 
 [gcode_macro _POST_HOME_XY]
 gcode:
-    _DO_SENSORLESS_STUFF TYPE=RUN AXIS={params.AXIS}
+    _SET_DRIVERS MODE=RUN AXIS={params.AXIS}
 
-[gcode_macro _DO_SENSORLESS_STUFF]
+[gcode_macro _SET_DRIVERS]
 gcode:
     {% set AXIS = params.AXIS %}
-    {% set TYPE = params.TYPE %}
+    {% set MODE = params.MODE %}
 
     {% set kinematics = printer.configfile.config.printer.kinematics %}
 
-    {% if printer["gcode_macro _USER_VARIABLES"].sensorless_homing_enabled %}
-        {% if TYPE == 'RUN' %}
-            M400
+    M400
+    {% if kinematics == "corexy" %}
+        _SET_TMC AXIS=X MODE={TYPE}
+        _SET_TMC AXIS=Y MODE={TYPE}
+    {% elif kinematics == "corexz" %}
+        {% if AXIS == 'X' %}
+            _SET_TMC AXIS=X MODE={TYPE}
+            _SET_TMC AXIS=Z MODE={TYPE}
+        {% elif AXIS == 'Y' %}
+            _SET_TMC AXIS=Y MODE={TYPE}
         {% endif %}
-        {% if kinematics == "corexy" %}
-            _SET_TMC_CURRENT AXIS=X TYPE={TYPE}
-            _SET_TMC_CURRENT AXIS=Y TYPE={TYPE}
-        {% elif kinematics == "corexz" %}
-            {% if AXIS == 'X' %}
-                _SET_TMC_CURRENT AXIS=X TYPE={TYPE}
-                _SET_TMC_CURRENT AXIS=Z TYPE={TYPE}
-            {% elif AXIS == 'Y' %}
-                _SET_TMC_CURRENT AXIS=Y TYPE={TYPE}
-            {% endif %}
-        {% elif kinematics == "cartesian" %}
-            _SET_TMC_CURRENT AXIS={AXIS} TYPE={TYPE}
-        {% endif %}
-        {% if TYPE == 'HOME' %}
-            M400
-        {% endif %}
+    {% elif kinematics == "cartesian" %}
+        _SET_TMC AXIS={AXIS} MODE={TYPE}
     {% endif %}
+    M400
 
-[gcode_macro _SET_TMC_CURRENT]
+[gcode_macro _SET_TMC]
 gcode:
     {% set _u_vars = printer["gcode_macro _USER_VARIABLES"] %}
     
     {% set sensorless_current_factor = _u_vars.sensorless_current_factor|float / 100 %}
     {% set AXIS = params.AXIS|upper %}
-    {% set TYPE = params.TYPE|upper %} #allowed values HOME | RUN
+    {% set MODE = params.MODE|upper %} #allowed values HOME | RUN
     {% set driver = _u_vars[AXIS|lower ~ '_driver'] %}
     
     {% if AXIS in 'XYZ' %}
-        {% set current = printer.configfile.config[driver ~ ' stepper_' ~ AXIS|lower].run_current|float}
-        {% if TYPE== 'HOME' %}
+        {% set current = printer.configfile.config[driver ~ ' stepper_' ~ AXIS|lower].run_current|float %}
+        {% if MODE== 'HOME' %}
             {% set current = current * sensorless_current_factor %}
         {% endif %}
         SET_TMC_CURRENT STEPPER=stepper_{AXIS|lower} CURRENT={current}

--- a/macros/base/homing/sensorless_homing.cfg
+++ b/macros/base/homing/sensorless_homing.cfg
@@ -1,0 +1,53 @@
+[gcode_macro _PRE_HOME_XY]
+gcode:
+    _DO_SENSORLESS_STUFF TYPE=HOME AXIS={params.AXIS}
+
+[gcode_macro _POST_HOME_XY]
+gcode:
+    _DO_SENSORLESS_STUFF TYPE=RUN AXIS={params.AXIS}
+
+[gcode_macro _DO_SENSORLESS_STUFF]
+gcode:
+    {% set AXIS = params.AXIS %}
+    {% set TYPE = params.TYPE %}
+
+    {% set kinematics = printer.configfile.config.printer.kinematics %}
+
+    {% if printer["gcode_macro _USER_VARIABLES"].sensorless_homing_enabled %}
+        {% if TYPE == 'RUN' %}
+            M400
+        {% endif %}
+        {% if kinematics == "corexy" %}
+            _SET_TMC_CURRENT AXIS=X TYPE={TYPE}
+            _SET_TMC_CURRENT AXIS=Y TYPE={TYPE}
+        {% elif kinematics == "corexz" %}
+            {% if AXIS == 'X' %}
+                _SET_TMC_CURRENT AXIS=X TYPE={TYPE}
+                _SET_TMC_CURRENT AXIS=Z TYPE={TYPE}
+            {% elif AXIS == 'Y' %}
+                _SET_TMC_CURRENT AXIS=Y TYPE={TYPE}
+            {% endif %}
+        {% elif kinematics == "cartesian" %}
+            _SET_TMC_CURRENT AXIS={AXIS} TYPE={TYPE}
+        {% endif %}
+        {% if TYPE == 'HOME' %}
+            M400
+        {% endif %}
+    {% endif %}
+
+[gcode_macro _SET_TMC_CURRENT]
+gcode:
+    {% set _u_vars = printer["gcode_macro _USER_VARIABLES"] %}
+    
+    {% set sensorless_current_factor = _u_vars.sensorless_current_factor|float / 100 %}
+    {% set AXIS = params.AXIS|upper %}
+    {% set TYPE = params.TYPE|upper %} #allowed values HOME | RUN
+    {% set driver = _u_vars[AXIS|lower ~ '_driver'] %}
+    
+    {% if AXIS in 'XYZ' %}
+        {% set current = printer.configfile.config[driver ~ ' stepper_' ~ AXIS|lower].run_current|float}
+        {% if TYPE== 'HOME' %}
+            {% set current = current * sensorless_current_factor %}
+        {% endif %}
+        SET_TMC_CURRENT STEPPER=stepper_{AXIS|lower} CURRENT={current}
+    {% endif %}

--- a/macros/base/probing/dockable_probe.cfg
+++ b/macros/base/probing/dockable_probe.cfg
@@ -23,24 +23,16 @@ gcode:
     # all the macros initially assume absolute positioning
     G90
 
-[gcode_macro _HOMING_VARIABLES]
-gcode:
-    {% set Reset  = params.RESET|default(0)  %}
-    {% if Reset %}
-        SET_GCODE_VARIABLE MACRO=_PROBE_VARIABLES VARIABLE=probe_lock VALUE={ False }
-    {% endif %}
-
-
 [gcode_macro _ATTACH_PROBE_LOCK]
 description: Attaches probe, can only be docked after unlocking
 gcode:
     _ATTACH_PROBE
-    SET_GCODE_VARIABLE MACRO=_PROBE_VARIABLES VARIABLE=probe_lock VALUE={ True }
+    _PROBE_LOCK
 
 [gcode_macro _DOCK_PROBE_UNLOCK]
 description: Docks probe even if it was locked
 gcode:
-    SET_GCODE_VARIABLE MACRO=_PROBE_VARIABLES VARIABLE=probe_lock VALUE={ False }
+    _PROBE_UNLOCK
     _DOCK_PROBE
 
 [gcode_macro _PROBE_UNLOCK]
@@ -118,21 +110,15 @@ gcode:
 
     # If probe not attached and locked
     {% elif not probe_attached and not probe_lock %}
-        {% if verbose %}
-            { action_respond_info("Attaching Probe") }
-        {% endif %}
+        { action_respond_info("Attaching Probe") if verbose }
 
         {% if probe_type_enabled == "dockable_virtual" and not 'z' in printer.toolhead.homed_axes %}
-            {% if verbose %}
-                { action_respond_info("Attaching the probe can only be done during G28 if Z is not already homed") }
-            {% endif %}
+            { action_respond_info("Attaching the probe can only be done during G28 if Z is not already homed") if verbose }
         {% endif %}
 
         # Move to safe Z
         {% if (printer.toolhead.position.z < probe_min_z_travel) %}
-            {% if verbose %}
-                { action_respond_info("Moving to a safe Z distance") }
-            {% endif %}
+            { action_respond_info("Moving to a safe Z distance") if verbose }
             G0 Z{probe_min_z_travel} F{z_drop_speed}
         {% endif %}
 
@@ -166,17 +152,13 @@ gcode:
         _CHECK_PROBE action=attach
 
     {% elif probe_lock %}
-        {% if verbose %}
-            { action_respond_info("Probe locked!") }
-        {% endif %}
+        { action_respond_info("Probe locked!") if verbose }
 
         # Probe attached, do nothing
         _CHECK_PROBE action=query
 
     {% else %}
-        {% if verbose %}
-            { action_respond_info("Probe already attached!") }
-        {% endif %}
+        { action_respond_info("Probe already attached!") if verbose }
 
         # Probe attached, do nothing
         _CHECK_PROBE action=query
@@ -227,21 +209,15 @@ gcode:
 
     # If probe not attached and not locked
     {% elif probe_attached and not probe_lock %}
-        {% if verbose %}
-            { action_respond_info("Docking Probe") }
-        {% endif %}
+        { action_respond_info("Docking Probe") if verbose }
 
         {% if probe_type_enabled == "dockable_virtual" and not 'z' in printer.toolhead.homed_axes %}
-            {% if verbose %}
-                { action_respond_info("Docking the probe can only be done during G28 if Z is not already homed") }
-            {% endif %}
+            { action_respond_info("Docking the probe can only be done during G28 if Z is not already homed") if verbose }
         {% endif %}
 
         # Move to safe Z
         {% if (printer.toolhead.position.z < probe_min_z_travel) %}
-            {% if verbose %}
-                { action_respond_info("Moving to a safe Z distance") }
-            {% endif %}
+            { action_respond_info("Moving to a safe Z distance") if verbose }
             G0 Z{probe_min_z_travel} F{z_drop_speed}
         {% endif %}
 
@@ -281,17 +257,13 @@ gcode:
         _CHECK_PROBE action=dock
 
     {% elif probe_lock %}
-        {% if verbose %}
-            { action_respond_info("Probe locked!") }
-        {% endif %}
+        { action_respond_info("Probe locked!") if verbose }
 
         # Probe docked, do nothing
         _CHECK_PROBE action=query
 
     {% else %}
-        {% if verbose %}
-            { action_respond_info("Probe already docked!") }
-        {% endif %}
+        { action_respond_info("Probe already docked!") if verbose }
 
         # Probe docked, do nothing
         _CHECK_PROBE action=query


### PR DESCRIPTION
Refacto of homing_override
- exclude sensorless things when not required adding _PRE_HOME_XY/_POST_HOME_XY macros, create sensorless_homing.cfg
- rewrite as loop to avoid redondant structures

I didn't test it yet/ probably some typos. Just to know if you are ok with such radical changes.
