### PR TITLE
Material_presets management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Klippain
+# Klippain-Chocolate
 
-> Klippain - The pain-free recipe for (french)bread and butter Klipper configuration!
+> Klippain - The pain-free recipe for (french)bread and butter Klipper configuration! (Now it's better with some chocolate)
+
 
 Klippain is a generic, modular, and highly customizable Klipper configuration for 3D printers. Designed for use on various machines such as Cartesian, CoreXY and CoreXZ, it has been reported working correctly on Voron V2.4, Voron Trident, Voron V0, Voron SwitchWire, TriZero, VZbot, Ender5, Ender3, Prusas, etc...
 
@@ -25,7 +26,7 @@ To install Klippain, first ensure you have already Klipper, Moonraker, and a Web
 Then, run the installation script using the following command over SSH. This script will backup your old configuration, download this GitHub repository to your RaspberryPi home directory, and set up Klippain in `~/printer_data/config`. You will also be prompted to select and install MCU board_pins templates. This is recommended for faster `mcu.cfg` setup, but you can do it manually later if you prefer.
 
 ```bash
-wget -O - https://raw.githubusercontent.com/Frix-x/klippain/main/install.sh | bash
+wget -O - https://raw.githubusercontent.com/elpopo-eng/klippain-chocolate/main/install.sh | bash
 ```
 
 Finally, Klippain requires a few simple steps to configure and customize it for your printer: please follow the [configuration guide](./docs/configuration.md).
@@ -42,7 +43,7 @@ In case Klippain doesn't suit your needs or if you installed it by mistake, you 
 To run the uninstall script, execute the following command over SSH:
 
 ```bash
-wget -O - https://raw.githubusercontent.com/Frix-x/klippain/main/uninstall.sh | bash
+wget -O - https://raw.githubusercontent.com/elpopo-eng/klippain-chocolate/main/uninstall.sh | bash
 ```
 
   > **Note**:

--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -57,10 +57,12 @@ resolution: 0.1
 
 [include ../macros/helpers/filament_swap.cfg]
 [include ../macros/helpers/heatsoak.cfg]
+[include ../macros/helpers/material_presets.cfg]
 [include ../macros/helpers/prime_line.cfg]
 [include ../macros/helpers/nozzle_cleaning.cfg]
 [include ../macros/helpers/temp_check.cfg]
 
 [include ../macros/miscs/compatibility.cfg]
 [include ../macros/miscs/debugging.cfg]
+[include ../macros/miscs/prompt.cfg]
 [include ../macros/miscs/startup.cfg]

--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -86,7 +86,7 @@ gcode:
 
     # If a filament sensor is connected, re-enable it in case it was disabled during printing
     {% if filament_sensor_enabled %}
-        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
+        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE={printer["gcode_macro _MATERIAL"].current.filament_sensor}
     {% endif %}
     
     # clear pause_next_layer and pause_at_layer as preparation for next print

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -84,7 +84,7 @@ gcode:
 
     # If a filament sensor is connected, re-enable it in case it was disabled during printing
     {% if filament_sensor_enabled %}
-        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
+        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE={printer["gcode_macro _MATERIAL"].current.filament_sensor}
     {% endif %}
 
     SET_PAUSE_NEXT_LAYER ENABLE=0

--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -2,7 +2,7 @@
 description: Park the toolhead at the back and retract some filament if the nozzle is hot
 gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
-    {% set material = printer['gcode_macro START_PRINT'].material %}
+    {% set material = printer["gcode_macro _MATERIAL"].current %}
 
     {% set Px, Py = printer["gcode_macro _USER_VARIABLES"].park_position_xy|map('float') %}
     {% set Px = params.X|default(Px)|float %}
@@ -43,12 +43,7 @@ gcode:
                 {% endif %}
                 G10
             {% else %}                              # otherwise:
-                {% if printer["gcode_macro _USER_VARIABLES"].material_parameters[material] is defined %}          # use material parameter if available for retract, otherwise use default value
-                    {% set E = printer["gcode_macro _USER_VARIABLES"].material_parameters[material].retract_length|default(1.7) %}
-                {% else %}
-                    {% set E = 1.7 %}
-                {% endif %}
-
+                {% set E = material.retract_length|default(1.7) %}
                 {% if verbose %}
                     RESPOND MSG="Firmware retraction disabled, Extruder retraction = {E}"
                 {% endif %}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -80,10 +80,13 @@ gcode:
         { action_raise_error("Add this new material to your material_parameters variable!") }
     {% else %}
         RESPOND MSG="Material '{MATERIAL}' is used"
+        # save current material
+        SAVE_VARIABLE VARIABLE=current_material_name value='"{MATERIAL}"'
+
+        #set curent material parameters
         {% set material = printer["gcode_macro _USER_VARIABLES"].material_parameters[MATERIAL] %}
-        {% if filament_sensor_enabled %}
-            {% set filament_sensor_enabled = material.filament_sensor | default(1) %}
-        {% endif %}
+        SET_GCODE_VARIABLE MACRO=_MATERIAL VARIABLE=current VALUE='{ material|tojson }'
+        
     {% endif %}
     
     # --------------------------------
@@ -134,7 +137,7 @@ gcode:
     {% if firmware_retraction_enabled %}
         SET_RETRACTION RETRACT_LENGTH={material.retract_length} RETRACT_SPEED={material.retract_speed} UNRETRACT_EXTRA_LENGTH={material.unretract_extra_length} UNRETRACT_SPEED={material.unretract_speed}
     {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={material.pressure_advance}
+    SET_PRESSURE_ADVANCE ADVANCE={material.pressure_advance} SMOOTH_TIME={material.pressure_advance_smooth_time}
 
     # Homing before START_PRINT movements and actions
     {% if force_homing_in_start_print %}
@@ -142,6 +145,7 @@ gcode:
     {% else %}
         _CG28
     {% endif %}
+
 
     # If an MMU is enabled, initialize it for the print
     {% if klippain_mmu_enabled %}
@@ -175,7 +179,7 @@ gcode:
 
 
     {% if filament_sensor_enabled %}
-        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
+        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE={material.filament_sensor}
     {% endif %}
 
     # And.... Goooo!

--- a/macros/helpers/material_presets.cfg
+++ b/macros/helpers/material_presets.cfg
@@ -1,0 +1,223 @@
+## Macros to manage material settings
+# The following macros are a derivative work from _kbobine filament settings_ project
+
+# This config file contains macros that are used in conjuction with material settings
+[gcode_macro _MATERIAL]
+variable_default: {  
+        "pressure_advance": 0.048,
+        "retract_length": 0.5,
+        "unretract_extra_length": 0,
+        "retract_speed": 40,
+        "unretract_speed": 30,
+        "filter_speed": 80,
+        "additional_z_offset": 0,
+        "filament_sensor": 1,
+
+        "prime_line_pressure_length": 0,
+        "purge_retract_distance": 0,
+        "purge_speed": 5,
+    }
+gcode:
+
+### MACROS ###
+# Add/set a material to the material_table
+[gcode_macro SET_MATERIAL]
+description: Add/Set material to config, if a parameter is empty it will use the default value
+gcode:
+    {% set _ = params.NAME %}
+#######################################################################
+## Declare entry params Only for GUI (Fluidd/Mainsail/Klipperscreen) ##
+## Entries must correspond to the variable_default keys
+    {% set _ = params.PRESSURE_ADVANCE %}
+    {% set _ = params.RETRACT_LENGTH %}
+    {% set _ = params.UNRETRACT_EXTRA_LENGTH %}
+    {% set _ = params.RETRACT_SPEED %}
+    {% set _ = params.UNRETRACT_SPEED %}
+    {% set _ = params.FILTER_SPEED %}
+    {% set _ = params.ADDITIONAL_Z_OFFSET %}
+    {% set _ = params.FILAMENT_SENSOR %}
+
+    {% set _ = params.PRIME_LINE_PRESSURE_LENGTH %}
+    {% set _ = params.PURGE_RETRACT_DISTANCE %}
+    {% set _ = params.PURGE_SPEED %}
+#######################################################################
+    _SET_MATERIAL {rawparams}
+
+
+# Remove a material from the material_table
+[gcode_macro REMOVE_MATERIAL]
+description: Remove material from config
+gcode:
+    {% set _p = params %}   
+    {% set fs_table= printer["gcode_macro _USER_VARIABLES"].material_parameters%}
+    {% set NAME = params.NAME | string %}
+    
+    {% if _p.CONFIRM == "1" %}
+        _PROMPT_CLOSE
+        {% if NAME|length %}
+            {% if fs_table[NAME] %}
+                {% set _= fs_table.pop(NAME) %}
+                SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE='{ fs_table|tojson }'
+                _SAVE_MATERIAL_PROFILES
+            {% else %}
+                {action_raise_error("Material '%s' not found" % NAME)}
+            {% endif %}
+        {% else %}
+            {action_raise_error("No material specified")}
+        {% endif %}
+    {% else %}
+        _PROMPT_QUESTION TITLE="Remove Material" MSG="Are you sure you want to remove '{NAME}' from material_table ?" ACTION="REMOVE_MATERIAL NAME=\\\"{NAME}\\\" CONFIRM=1"
+    {% endif %}
+
+# Reset material_table
+[gcode_macro RESET_MATERIALS]
+description: Reset material_table
+gcode:
+    {% set _p = params %}
+    {% set fs_table = printer.configfile.config["gcode_macro _USER_VARIABLES"].variable_material_parameters|replace('\n','')  %}
+    
+    {% if _p.CONFIRM == "1" %}
+        _PROMPT_CLOSE
+        {% if fs_table|length %}
+            SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE="{ fs_table }"
+            _SAVE_MATERIAL_PROFILES
+            _LOAD_MATERIAL_PROFILES
+        {% else %}
+            {action_raise_error("No materials found in configfile")}
+        {% endif %}
+    {% else %}
+        _PROMPT_QUESTION TITLE="Reset Material settings" MSG="Are you sure you want to reset material_table ? All changes in material_table will be erased" ACTION="RESET_MATERIALS CONFIRM=1"
+    {% endif %}
+
+### BACKEND ###
+# Load material settings from the material_table
+[gcode_macro _LOAD_MATERIAL]
+description: Load material settings
+gcode:
+    {% set _p = params %}
+    {% set fs_table= printer["gcode_macro _USER_VARIABLES"].material_parameters %}
+    {% set NAME = params.NAME|default("") %}
+    
+    {% if NAME|length %}
+        {% if not fs_table[NAME] %}
+            _PROMPT_SELECT TITLE="Select material" MSG="Parameters for '{ NAME
+              }' not found, load filament settings from : " OPTIONS="{ fs_table.keys()|join(',')
+              },default" ACTION="_DUPLICATE_MATERIAL NAME=\\\"{NAME}\\\"" KEY=SOURCE
+        {% endif %}
+    {% else %}
+        {action_raise_error("No material specified") }
+    {% endif %}
+
+# Set material settings from the material_table
+[gcode_macro _DUPLICATE_MATERIAL]
+description: Set material settings from source
+gcode:
+    {% set _p = params %}
+    {% set fs_table= printer["gcode_macro _USER_VARIABLES"].material_parameters %}
+    {% set default = printer["gcode_macro _MATERIAL"].default %}
+    {% set NAME = _p.NAME|default("") %}
+    {% set SOURCE= _p.SOURCE %}
+    
+    _PROMPT_CLOSE
+    {% if NAME|length and SOURCE|length%}
+        {% if SOURCE == "default" %}
+            {% set _=fs_table.update({NAME:default}) %}
+        {% elif fs_table[SOURCE] %}
+            {% set _=fs_table.update({NAME:fs_table[SOURCE]}) %}
+        {% else %}
+            {action_raise_error("Source material '%s' not found" % SOURCE)}
+        {% endif %}
+        SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE='{ fs_table|tojson }'
+        _PROMPT_QUESTION TITLE="Save Material settings" MSG="Do you want to save the settings for {NAME} in material_table ?" ACTION="_SAVE_MATERIAL_PROFILES"
+    {% else %}
+        {action_raise_error("NAME must be specified") }
+    {% endif %}
+
+# Records the material settings in the material_table
+[gcode_macro _SET_MATERIAL]
+description: Set material settings
+gcode:
+
+    {% set _p=params %}
+## remove empty parameters (Fluidd hack)
+    {% for param in _p.copy() if _p[param] == "" %}
+        {% set _= _p.pop(param) %}
+    {% endfor %}
+
+## load variables
+    {% set fs_table = printer["gcode_macro _USER_VARIABLES"].material_parameters%}
+    {% set NAME = _p.NAME|string %}
+    {% set default = printer["gcode_macro _MATERIAL"].default %}
+##  
+    {% if NAME|length %}
+        {% if not fs_table[NAME] %}
+            {% set _= fs_table.update({NAME:default}) %}
+        {% endif %}
+        {% for param, value in _p.items() if param | lower in default %}
+            {% set _= fs_table[NAME].update({param|lower :
+                value|int if (value|float == value|int and value|float != 0.0) or value == '0' else (
+                value|float if value|float != 0.0 else 
+                value|string
+                )}) %}
+        {% endfor %}
+        SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE='{ fs_table|tojson }'
+        _PROMPT_QUESTION TITLE="Save Material settings" MSG="Do you want to save the settings for {NAME} in material_table ?" ACTION="_SAVE_MATERIAL_PROFILES"
+    {% else %}
+        {action_raise_error("No settings to apply, NAME is empty")}
+    {% endif %}
+
+# Load material settings from the material_table
+[gcode_macro _LOAD_MATERIAL_PROFILES]
+description: Load material settings from the material_table
+gcode:
+    {% set fs_table = printer.save_variables.variables.material_table | default({}) %}
+    {% set default = printer["gcode_macro _MATERIAL"].default %}
+    {% if fs_table|length > 0 %}
+        {% for name, settings in fs_table.items() %}
+            # Add missing parameters from default
+            {% for parameter in default if not settings[parameter] %}
+                {% set _=fs_table[name].update( {parameter:default[parameter]} ) %}
+            {% endfor %}
+        {% endfor %}
+        SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE='{ fs_table|tojson }'
+    {% else %}
+        {action_raise_error("No materials found in material_table")}
+    {% endif %}
+
+# Save material settings to the material_table
+[gcode_macro _SAVE_MATERIAL_PROFILES]
+description: Save material settings to the material_table
+gcode:
+    {% set fs_table = printer["gcode_macro _USER_VARIABLES"].material_parameters | default({}) %}
+    {% set default = printer["gcode_macro _MATERIAL"].default %}
+    {% set toremove={}%}
+   
+    _PROMPT_CLOSE
+    {% if fs_table|length %}
+        {% for name, settings in fs_table.copy().items() %}
+            # Remove parameters that are the same as the default
+            {% for parameter in default 
+                if settings[parameter] == default[parameter] %}
+                {% set _=fs_table[name].pop(parameter) %}
+            {% endfor %}
+            # Remove parameters that are not in default
+            {% for parameter in settings.copy() if parameter not in default %}
+                {% set _=fs_table[name].pop(parameter) %}
+            {% endfor %}
+        {% endfor %}
+        SAVE_VARIABLE VARIABLE=material_table value='{ fs_table|tojson }'
+    {% else %}
+        {action_raise_error("No material settings found in material_parameters")}
+    {% endif %}
+
+### BACKWARD COMPATIBILITY
+# Migrate config Apply the material, could be removed in a future release
+[gcode_macro _MIGRATE_MATERIAL_SETTINGS]
+gcode:
+    {% set fs_table = printer.save_variables.variables.material_table | default({}) %}
+    {% if fs_table|length == 0 %}
+        ## Migrate old material_parameters to material_table in save_variables
+        _SAVE_MATERIAL_PROFILES
+        RESPOND TYPE=error MSG="_USER_VARIABLES material_parameters are now stored into Save_variables !"
+        RESPOND TYPE=echo MSG="Use SET_MATERIAL to add or edit a material"
+    {% endif %}

--- a/macros/helpers/material_presets.cfg
+++ b/macros/helpers/material_presets.cfg
@@ -5,6 +5,7 @@
 [gcode_macro _MATERIAL]
 variable_default: {  
         "pressure_advance": 0.048,
+        "pressure_advance_smooth_time": 0.015,
         "retract_length": 0.5,
         "unretract_extra_length": 0,
         "retract_speed": 40,
@@ -13,10 +14,15 @@ variable_default: {
         "additional_z_offset": 0,
         "filament_sensor": 1,
 
-        "prime_line_pressure_length": 0,
-        "purge_retract_distance": 0,
-        "purge_speed": 5,
+        "prime_line_pressure_length": 18,   # distance to push filament to add  pressure into hotend (value near purge_retract_distanceif you purge before print )
+        "prime_line_purge_distance": 30,    # length of filament to purge (in mm)
+        "prime_line_flowrate": 10,          # mm3/s used for the prime line
+        "purge_retract_distance": 20,       # Amount to retract after purge (in mm) (Should be near the prime_pressure_lenght)
+        "purge_speed": 2.5,                 # Speed to purge (in mm/s)
+        "purge_distance": 30,               # Amount to purge (in mm)
     }
+variable_current: {  
+    }    
 gcode:
 
 ### MACROS ###
@@ -29,6 +35,7 @@ gcode:
 ## Declare entry params Only for GUI (Fluidd/Mainsail/Klipperscreen) ##
 ## Entries must correspond to the variable_default keys
     {% set _ = params.PRESSURE_ADVANCE %}
+    {% set _ = params.PRESSURE_ADVANCE_SMOOTH_TIME %}
     {% set _ = params.RETRACT_LENGTH %}
     {% set _ = params.UNRETRACT_EXTRA_LENGTH %}
     {% set _ = params.RETRACT_SPEED %}
@@ -38,8 +45,11 @@ gcode:
     {% set _ = params.FILAMENT_SENSOR %}
 
     {% set _ = params.PRIME_LINE_PRESSURE_LENGTH %}
+    {% set _ = params.PRIME_LINE_PURGE_DISTANCE %}
+    {% set _ = params.PRIME_LINE_FLOWRATE %}
     {% set _ = params.PURGE_RETRACT_DISTANCE %}
     {% set _ = params.PURGE_SPEED %}
+    {% set _ = params.PURGE_DISTANCE %}
 #######################################################################
     _SET_MATERIAL {rawparams}
 
@@ -220,4 +230,14 @@ gcode:
         _SAVE_MATERIAL_PROFILES
         RESPOND TYPE=error MSG="_USER_VARIABLES material_parameters are now stored into Save_variables !"
         RESPOND TYPE=echo MSG="Use SET_MATERIAL to add or edit a material"
+    {% endif %}
+
+
+# Restore last used material 
+[gcode_macro _RESTORE_LAST_USED_MATERIAL]
+description: Restore last used material
+gcode:
+    {% if printer.save_variables.variables.current_material_name is defined %}
+        {% set material = printer["gcode_macro _USER_VARIABLES"].material_parameters[printer.save_variables.variables.current_material_name] %}
+        SET_GCODE_VARIABLE MACRO=_MATERIAL VARIABLE=current VALUE='{ material|tojson }'
     {% endif %}

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -104,9 +104,9 @@ gcode:
 description: Purge a specific amount of filament ontop of the purge bucket
 gcode:
     {% set _u_vars = printer["gcode_macro _USER_VARIABLES"] %}
-    {% set DISTANCE = params.DISTANCE|default(_u_vars.purge_distance)|int %}
-    {% set RETRACT = params.RETRACT|default(_u_vars.purge_retract_distance)|int %}
-    {% set PURGE_SPEED = params.PURGE_SPEED|default(_u_vars.purge_speed)|int %}
+    {% set DISTANCE = params.DISTANCE|default(printer["gcode_macro _MATERIAL"].current.purge_distance)|int %}
+    {% set RETRACT = params.RETRACT|default(printer["gcode_macro _MATERIAL"].current.purge_retract_distance)|int %}
+    {% set PURGE_SPEED = params.PURGE_SPEED|default(printer["gcode_macro _MATERIAL"].current.purge_speed)|int %}
     {% set OOZE_TIME = params.OOZE_TIME|default(_u_vars.purge_ooze_time)|int %}
     {% set TEMP = params.TEMP|default(_u_vars.print_default_extruder_temp)|float %}
     {% set Z_DROP = params.Z_DROP|default(1)|int %}

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -1,11 +1,12 @@
 [gcode_macro PRIMELINE]
 gcode:
+
     # Base macro parameters
     {% set prime_line_length = params.LINE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_length)|float %}
-    {% set prime_line_purge_distance = params.PURGE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_purge_distance)|float %}
-    {% set prime_line_flowrate = params.FLOWRATE|default(printer["gcode_macro _USER_VARIABLES"].prime_line_flowrate)|float %}
+    {% set prime_line_purge_distance = params.PURGE_LENGTH|default(printer["gcode_macro _MATERIAL"].current.prime_line_purge_distance)|float %}
+    {% set prime_line_flowrate = params.FLOWRATE|default(printer["gcode_macro _MATERIAL"].current.prime_line_flowrate)|float %}
     {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|default(0.6)|float %}
-    {% set prime_line_pressure_lenght = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_pressure_lenght)|default(18)|float %}
+    {% set prime_line_pressure_length = params.LINE_HEIGHT|default(printer["gcode_macro _MATERIAL"].current.prime_line_pressure_length)|default(18)|float %}
     {% set prime_line_adaptive = params.ADAPTIVE_MODE|default(1)|int %}
     {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin)|default(5.0)|float %} # Used only in adaptive mode
     
@@ -111,7 +112,7 @@ gcode:
 
     # Add pressure in the nozzle
     G92 E0
-    G1 E{prime_line_pressure_lenght} F150
+    G1 E{prime_line_pressure_length} F150
 
     # Prime line
     G92 E0

--- a/macros/miscs/prompt.cfg
+++ b/macros/miscs/prompt.cfg
@@ -1,0 +1,39 @@
+### GUI functions
+# Mainsail introduces a new way to interact with the user, using the RESPOND command.
+# This snippet provides a set of macros to create prompts and messages boxes in the GUI.
+# it also works with Fluidd and Klipperscreen.
+
+# confirmation prompt
+[gcode_macro _PROMPT_QUESTION]
+gcode:
+    RESPOND TYPE=command MSG="action:prompt_begin {params.TITLE|default("Klippain-Chocolate")}"
+    RESPOND TYPE=command MSG="action:prompt_text {params.MSG}"
+    RESPOND TYPE=command MSG="action:prompt_footer_button Yes|{params.ACTION}"
+    RESPOND TYPE=command MSG="action:prompt_footer_button No|_PROMPT_CLOSE|error"
+    RESPOND TYPE=command MSG="action:prompt_show"
+
+# message box prompt
+[gcode_macro _PROMPT_MSGBOX]
+gcode:
+    RESPOND TYPE=command MSG="action:prompt_begin {params.TITLE|default("Klippain-Chocolate")}"
+    RESPOND TYPE=command MSG="action:prompt_text {params.MSG}"
+    RESPOND TYPE=command MSG="action:prompt_footer_button OK|_PROMPT_CLOSE|error"
+    RESPOND TYPE=command MSG="action:prompt_show"
+
+# selection prompt
+# Usage: _PROMPT_SELECT TITLE=<TITLE> MSG=<MSG> OPTIONS=<comma separated values> 
+#           ACTION=<MACRO> KEY=<PARAM TO ADD TO ACTION MACRO WITH OPTION VALUE>
+[gcode_macro _PROMPT_SELECT]
+gcode:
+    RESPOND TYPE=command MSG="action:prompt_begin {params.TITLE|default("Klippain-Chocolate")}"
+    RESPOND TYPE=command MSG="action:prompt_text {params.MSG}"
+    {% for option in params.OPTIONS.split(",") %}
+        RESPOND TYPE=command MSG="action:prompt_button {option}|{params.ACTION} {params.KEY}=\"{option}\""
+    {% endfor %}
+    RESPOND TYPE=command MSG="action:prompt_footer_button ABORT|_PROMPT_CLOSE|error"
+    RESPOND TYPE=command MSG="action:prompt_show"
+
+# close prompt
+[gcode_macro _PROMPT_CLOSE]
+gcode:
+    RESPOND TYPE=command MSG="action:prompt_end"

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -39,6 +39,10 @@ gcode:
     ## Set the startup status LED
     _INIT_LEDS
 
+    ## init material settings
+    _MIGRATE_MATERIAL_SETTINGS
+    _LOAD_MATERIAL_PROFILES
+
     # build the start proint sequence
     _INIT_START_PRINT_ACTIONS
 

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -42,6 +42,8 @@ gcode:
     ## init material settings
     _MIGRATE_MATERIAL_SETTINGS
     _LOAD_MATERIAL_PROFILES
+    _RESTORE_LAST_USED_MATERIAL
+
 
     # build the start proint sequence
     _INIT_START_PRINT_ACTIONS

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -81,12 +81,12 @@ variable_safe_extruder_temp: 150
 variable_prime_line_adaptive_mode: True # using the adaptive primeline manages start point and direction automatically
 variable_prime_line_xy: 5, 2.5 # starting point
 variable_prime_line_direction: "X" # can also be set to "Y"
-variable_prime_line_length: 40 # length of the prime line on the bed (in mm)
-variable_prime_line_purge_distance: 30 # length of filament to purge (in mm)
-variable_prime_line_flowrate: 10 # mm3/s used for the prime line
 variable_prime_line_height: 0.6 # mm, used for actual cross section computation
+variable_prime_line_length: 40 # length of the prime line on the bed (in mm)
 variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
-variable_prime_line_pressure_lenght: 18 # distance to push filament to add  pressure into hotend (value near purge_retract_distanceif you purge before print )
+## move into materials variable_prime_line_flowrate: 10 # mm3/s used for the prime line
+## move into materials variable_prime_line_pressure_length: 18 # distance to push filament to add  pressure into hotend (value near purge_retract_distanceif you purge before print )
+## move into materials variable_prime_line_purge_distance: 30 # length of filament to purge (in mm)
 
 ## Park position used when pause, end_print, etc...
 variable_park_position_xy: -1, -1
@@ -175,46 +175,7 @@ variable_print_default_material: "XXX"
 ## there is a filter installed on the machine, filament sensor is on or off if installed, etc...
 ## If you are using another material, just extend the list bellow with a new material and everything should work :)
 variable_material_parameters: {
-        'PLA': {
-            'pressure_advance': 0.0525,
-            'retract_length': 0.75,
-            'unretract_extra_length': 0,
-            'retract_speed': 40,
-            'unretract_speed': 30,
-            'filter_speed': 0,
-            'additional_z_offset': 0,
-            'filament_sensor': 1
-        },
-        'PET': {
-            'pressure_advance': 0.0650,
-            'retract_length': 1.4,
-            'unretract_extra_length': 0,
-            'retract_speed': 30,
-            'unretract_speed': 20,
-            'filter_speed': 0,
-            'additional_z_offset': 0.020,
-            'filament_sensor': 1
-        },
-        'ABS': {
-            'pressure_advance': 0.0480,
-            'retract_length': 0.5,
-            'unretract_extra_length': 0,
-            'retract_speed': 40,
-            'unretract_speed': 30,
-            'filter_speed': 80,
-            'additional_z_offset': 0,
-            'filament_sensor': 1
-        },
-        'TPU': {
-            'pressure_advance': 0.0500,
-            'retract_length': 0.2,
-            'unretract_extra_length': 0,
-            'retract_speed': 5,
-            'unretract_speed': 5,
-            'filter_speed': 0,
-            'additional_z_offset': 0.040,
-            'filament_sensor': 0
-        }
+
     }
 
 
@@ -252,10 +213,10 @@ variable_brush_size: 40, 10 # Size of the brush (in mm)
 variable_brush_center_offset: 0 # Offset of the brush center to start brushing (in mm), + is towards max X (only for "standard" cleaning)
 variable_brushes: 6 # Number of brushes of the nozzle to perform
 variable_purge_bucket_xyz: -1, -1, -1 # Purge bucket position
-variable_purge_distance: 30 # Amount to purge (in mm)
 variable_purge_ooze_time: 10 # Time (in seconds) to wait after the purge to let the nozzle ooze before going to the brush
-variable_purge_retract_distance: 20 # Amount to retract after purge (in mm) (Should be near the prime_pressure_lenght)
-variable_purge_speed: 2.5 # Speed to purge (in mm/s)
+# move into materials variable_purge_distance: 30 # Amount to purge (in mm)
+# move into materials variable_purge_retract_distance: 20 # Amount to retract after purge (in mm) (Should be near the prime_pressure_lenght)
+# move into materials variable_purge_speed: 2.5 # Speed to purge (in mm/s)
 
 ## Servo angles used to define the retracted and deployed positions
 ## of the purge bucket and brush (if applicable). These variables are only used if a purge


### PR DESCRIPTION
This PR is an attempt to make easy the material preset management.

It stores material presets in `material_table` in  save_variables to allow persistent changes via UI . It still use `_USER_VARIABLES.variable_material_parameters` to make its integration easier in Klippain-Chocolate.  

A macro _MATERIAL contains a dict of the default values for each parameters, it can be easily overwritten in overrides.
The macro SET_MATERIAL is aligned with this dict to show parameters in UI.  

3 Frontend macros :
- SET_MATERIAL : Add/Set material to config/material_table, if a parameter is empty it will use the default value
- REMOVE_MATERIAL : Remove material from material_table
- RESET_MATERIALS: Reset material_table from configfile

Under the hood, several hidden macros are used to edit material_table. 

UI prompt helpers (message box, select, question) are used to interact with user. Those could be useful in other parts of the code. (park, calibration, ...) It uses a RESPOND hack introduce by MainsailCrew https://docs.mainsail.xyz/overview/features/macro-prompts
It is know to work with mainsail/fluidd/klipperscreen, but not with minidisplay/mobileraker.

  