### PR TITLE
Materials: Renaming parameters

### DIFF
--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -14,7 +14,7 @@ gcode:
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled %}
-    {% set retract_length = printer["gcode_macro _MATERIAL"].current.purge_retract_distance|float %}
+    {% set retract_length = printer["gcode_macro _MATERIAL"].current.standby_retract_length|float %}
     
     {% if "xyz" in printer.toolhead.homed_axes %}
         PARK

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -96,7 +96,7 @@ gcode:
     # Retract filament for easier swaps at the end of a print job 
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set mmu_unload = params.MMU_UNLOAD_AT_END|default(printer["gcode_macro _USER_VARIABLES"].mmu_unload_on_end_print)|default(0)|int %}
-    {% set retract_length = printer["gcode_macro _MATERIAL"].current.purge_retract_distance|float %}
+    {% set retract_length = printer["gcode_macro _MATERIAL"].current.standby_retract_length|float %}
 
     {% if klippain_mmu_enabled %}
         {% if printer.mmu.enabled and mmu_unload %}

--- a/macros/helpers/material_presets.cfg
+++ b/macros/helpers/material_presets.cfg
@@ -14,12 +14,14 @@ variable_default: {
         "additional_z_offset": 0,
         "filament_sensor": 1,
 
-        "prime_line_pressure_length": 18,   # distance to push filament to add  pressure into hotend (value near purge_retract_distanceif you purge before print )
-        "prime_line_purge_distance": 30,    # length of filament to purge (in mm)
+        "standby_retract_length": 20,       # Amount to retract after purge or endprint (in mm) to place filament in standby zone (Should be near the prime_pressure_lenght)
+
+        "prime_line_pressure_length": 18,   # distance to push filament to add  pressure into hotend (value near standby_retract_length if you purge before print )
+        "prime_line_purge_length": 30,      # length of filament to purge (in mm)
         "prime_line_flowrate": 10,          # mm3/s used for the prime line
-        "purge_retract_distance": 20,       # Amount to retract after purge (in mm) (Should be near the prime_pressure_lenght)
+
         "purge_speed": 2.5,                 # Speed to purge (in mm/s)
-        "purge_distance": 30,               # Amount to purge (in mm)
+        "purge_length": 30,                 # Amount to purge (in mm)
     }
 variable_current: {  
     }    
@@ -44,12 +46,13 @@ gcode:
     {% set _ = params.ADDITIONAL_Z_OFFSET %}
     {% set _ = params.FILAMENT_SENSOR %}
 
+    {% set _ = params.STANDBY_RETRACT_LENGTH %}
+
     {% set _ = params.PRIME_LINE_PRESSURE_LENGTH %}
-    {% set _ = params.PRIME_LINE_PURGE_DISTANCE %}
+    {% set _ = params.PRIME_LINE_PURGE_LENGTH %}
     {% set _ = params.PRIME_LINE_FLOWRATE %}
-    {% set _ = params.PURGE_RETRACT_DISTANCE %}
     {% set _ = params.PURGE_SPEED %}
-    {% set _ = params.PURGE_DISTANCE %}
+    {% set _ = params.PURGE_LENGTH %}
 #######################################################################
     _SET_MATERIAL {rawparams}
 

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -104,8 +104,8 @@ gcode:
 description: Purge a specific amount of filament ontop of the purge bucket
 gcode:
     {% set _u_vars = printer["gcode_macro _USER_VARIABLES"] %}
-    {% set DISTANCE = params.DISTANCE|default(printer["gcode_macro _MATERIAL"].current.purge_distance)|int %}
-    {% set RETRACT = params.RETRACT|default(printer["gcode_macro _MATERIAL"].current.purge_retract_distance)|int %}
+    {% set DISTANCE = params.DISTANCE|default(printer["gcode_macro _MATERIAL"].current.purge_length)|int %}
+    {% set RETRACT = params.RETRACT|default(printer["gcode_macro _MATERIAL"].current.standby_retract_length)|int %}
     {% set PURGE_SPEED = params.PURGE_SPEED|default(printer["gcode_macro _MATERIAL"].current.purge_speed)|int %}
     {% set OOZE_TIME = params.OOZE_TIME|default(_u_vars.purge_ooze_time)|int %}
     {% set TEMP = params.TEMP|default(_u_vars.print_default_extruder_temp)|float %}

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -3,7 +3,7 @@ gcode:
 
     # Base macro parameters
     {% set prime_line_length = params.LINE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_length)|float %}
-    {% set prime_line_purge_distance = params.PURGE_LENGTH|default(printer["gcode_macro _MATERIAL"].current.prime_line_purge_distance)|float %}
+    {% set prime_line_purge_length = params.PURGE_LENGTH|default(printer["gcode_macro _MATERIAL"].current.prime_line_purge_length)|float %}
     {% set prime_line_flowrate = params.FLOWRATE|default(printer["gcode_macro _MATERIAL"].current.prime_line_flowrate)|float %}
     {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|default(0.6)|float %}
     {% set prime_line_pressure_length = params.LINE_HEIGHT|default(printer["gcode_macro _MATERIAL"].current.prime_line_pressure_length)|default(18)|float %}
@@ -65,20 +65,20 @@ gcode:
     {% set filament_diameter = printer["configfile"].config["extruder"]["filament_diameter"]|float %}
     
     # We first compute the width of the prime line
-    {% set purge_volume = prime_line_purge_distance * 3.14159 * (filament_diameter / 2)**2 %}
+    {% set purge_volume = prime_line_purge_length * 3.14159 * (filament_diameter / 2)**2 %}
     {% set line_width = purge_volume / (prime_line_height * prime_line_length) %}
 
     # Then we check that the prime line cross section will not be problematic (exceeding Klipper max_extrude_cross_section)
     # or, if it's the case, we warn the user and add a correction to the length of filament to be purged
     {% if (prime_line_height * line_width) > max_extrude_cross_section %}
         {% if verbose %}
-            {action_respond_info("The prime_line_purge_distance of %.4f mm is too high and will exceed the max_extrude_cross_section!" % prime_line_purge_distance)}
+            {action_respond_info("The prime_line_purge_length of %.4f mm is too high and will exceed the max_extrude_cross_section!" % prime_line_purge_length)}
         {% endif %}
-        {% set prime_line_purge_distance = 0.98 * (max_extrude_cross_section * prime_line_length) / (3.14159 * (filament_diameter / 2)**2) %}
-        {% set purge_volume = prime_line_purge_distance * 3.14159 * (filament_diameter / 2)**2 %}
+        {% set prime_line_purge_length = 0.98 * (max_extrude_cross_section * prime_line_length) / (3.14159 * (filament_diameter / 2)**2) %}
+        {% set purge_volume = prime_line_purge_length * 3.14159 * (filament_diameter / 2)**2 %}
         {% set line_width = purge_volume / (prime_line_height * prime_line_length) %}
         {% if verbose %}
-            {action_respond_info("Klippain corrected the prime_line_purge_distance to %.4f mm" % prime_line_purge_distance)}
+            {action_respond_info("Klippain corrected the prime_line_purge_length to %.4f mm" % prime_line_purge_length)}
         {% endif %}
     {% endif %}
 
@@ -119,12 +119,12 @@ gcode:
     # Prime line
     G92 E0
     {% if prime_line_direction == "X" %}
-        G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
+        G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_length} F{speed}
         {% if prime_line_wipe %}
             G0 X{prime_line_x + prime_line_way*prime_line_wipe_length} F{St}
         {% endif %}
     {% elif prime_line_direction == "Y" %}
-        G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
+        G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_length} F{speed}
         {% if prime_line_wipe %}
             G0 Y{prime_line_y + prime_line_way*prime_line_wipe_length} F{St}
         {% endif %}        

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -85,8 +85,8 @@ variable_prime_line_height: 0.6 # mm, used for actual cross section computation
 variable_prime_line_length: 40 # length of the prime line on the bed (in mm)
 variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
 ## move into materials variable_prime_line_flowrate: 10 # mm3/s used for the prime line
-## move into materials variable_prime_line_pressure_length: 18 # distance to push filament to add  pressure into hotend (value near purge_retract_distanceif you purge before print )
-## move into materials variable_prime_line_purge_distance: 30 # length of filament to purge (in mm)
+## move into materials variable_prime_line_pressure_length: 18 # distance to push filament to add  pressure into hotend (value near standby_retract_lengthif you purge before print )
+## move into materials variable_prime_line_purge_length: 30 # length of filament to purge (in mm)
 variable_prime_line_wipe: False # enable a wipe of the nozzle after completing the prime line
 
 ## Length of filament to retract to disengage it from the heatbreak.
@@ -237,8 +237,8 @@ variable_brush_center_offset: 0 # Offset of the brush center to start brushing (
 variable_brushes: 6 # Number of brushes of the nozzle to perform
 variable_purge_bucket_xyz: -1, -1, -1 # Purge bucket position
 variable_purge_ooze_time: 10 # Time (in seconds) to wait after the purge to let the nozzle ooze before going to the brush
-# move into materials variable_purge_distance: 30 # Amount to purge (in mm)
-# move into materials variable_purge_retract_distance: 20 # Amount to retract after purge (in mm) (Should be near the prime_pressure_lenght)
+# move into materials variable_purge_length: 30 # Amount to purge (in mm)
+# move into materials variable_standby_retract_length: 20 # Amount to retract after purge (in mm) (Should be near the prime_pressure_lenght)
 # move into materials variable_purge_speed: 2.5 # Speed to purge (in mm/s)
 
 ## Servo angles used to define the retracted and deployed positions

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -85,7 +85,7 @@ variable_prime_line_height: 0.6 # mm, used for actual cross section computation
 variable_prime_line_length: 40 # length of the prime line on the bed (in mm)
 variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
 ## move into materials variable_prime_line_flowrate: 10 # mm3/s used for the prime line
-## move into materials variable_prime_line_pressure_length: 18 # distance to push filament to add  pressure into hotend (value near standby_retract_lengthif you purge before print )
+## move into materials variable_prime_line_pressure_length: 18 # distance to push filament to add  pressure into hotend (value near standby_retract_length if you purge before print )
 ## move into materials variable_prime_line_purge_length: 30 # length of filament to purge (in mm)
 variable_prime_line_wipe: False # enable a wipe of the nozzle after completing the prime line
 


### PR DESCRIPTION
For more consistent parameters in material db

`purge_retract_distance` -> `standby_retract_length`
`purge_distance` -> `purge_length`
`prime_line_purge_distance` -> `prime_line_purge_length`