### PR TITLE
No default value for  sense_resistor

### DIFF
--- a/config/hardware/axis/X/TMC/TMC2209_1-Motor.cfg
+++ b/config/hardware/axis/X/TMC/TMC2209_1-Motor.cfg
@@ -8,5 +8,5 @@ gcode:
 uart_pin: X_TMCUART
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0

--- a/config/hardware/axis/X/TMC/TMC2209_2-Motors.cfg
+++ b/config/hardware/axis/X/TMC/TMC2209_2-Motors.cfg
@@ -4,5 +4,5 @@
 uart_pin: X1_TMCUART
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0

--- a/config/hardware/axis/X/TMC/TMC5160_1-Motor.cfg
+++ b/config/hardware/axis/X/TMC/TMC5160_1-Motor.cfg
@@ -11,5 +11,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.075
+# sense_resistor: 0.075
 stealthchop_threshold: 0

--- a/config/hardware/axis/X/TMC/TMC5160_2-Motors.cfg
+++ b/config/hardware/axis/X/TMC/TMC5160_2-Motors.cfg
@@ -7,5 +7,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.075
+# sense_resistor: 0.075
 stealthchop_threshold: 0

--- a/config/hardware/axis/Y/TMC/TMC2209_1-Motor.cfg
+++ b/config/hardware/axis/Y/TMC/TMC2209_1-Motor.cfg
@@ -8,5 +8,5 @@ gcode:
 uart_pin: Y_TMCUART
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0

--- a/config/hardware/axis/Y/TMC/TMC2209_2-Motors.cfg
+++ b/config/hardware/axis/Y/TMC/TMC2209_2-Motors.cfg
@@ -4,5 +4,5 @@
 uart_pin: Y1_TMCUART
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0

--- a/config/hardware/axis/Y/TMC/TMC5160_1-Motor.cfg
+++ b/config/hardware/axis/Y/TMC/TMC5160_1-Motor.cfg
@@ -11,5 +11,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.075
+# sense_resistor: 0.075
 stealthchop_threshold: 0

--- a/config/hardware/axis/Y/TMC/TMC5160_2-Motors.cfg
+++ b/config/hardware/axis/Y/TMC/TMC5160_2-Motors.cfg
@@ -7,5 +7,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.075
+# sense_resistor: 0.075
 stealthchop_threshold: 0

--- a/config/hardware/axis/Z/TMC/TMC2209_1-Motor.cfg
+++ b/config/hardware/axis/Z/TMC/TMC2209_1-Motor.cfg
@@ -10,5 +10,5 @@ gcode:
 uart_pin: Z_TMCUART
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0

--- a/config/hardware/axis/Z/TMC/TMC2209_3-Motors.cfg
+++ b/config/hardware/axis/Z/TMC/TMC2209_3-Motors.cfg
@@ -4,12 +4,12 @@
 uart_pin: Z1_TMCUART
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0
 
 [tmc2209 stepper_z2]
 uart_pin: Z2_TMCUART
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0

--- a/config/hardware/axis/Z/TMC/TMC2209_4-Motors.cfg
+++ b/config/hardware/axis/Z/TMC/TMC2209_4-Motors.cfg
@@ -4,5 +4,5 @@
 uart_pin: Z3_TMCUART
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0

--- a/config/hardware/axis/Z/TMC/TMC5160_1-Motor.cfg
+++ b/config/hardware/axis/Z/TMC/TMC5160_1-Motor.cfg
@@ -14,5 +14,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.075
+# sense_resistor: 0.075
 stealthchop_threshold: 0

--- a/config/hardware/axis/Z/TMC/TMC5160_3-Motors.cfg
+++ b/config/hardware/axis/Z/TMC/TMC5160_3-Motors.cfg
@@ -8,7 +8,7 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.075
+# sense_resistor: 0.075
 stealthchop_threshold: 0
 
 [tmc5160 stepper_z2]
@@ -19,5 +19,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.075
+# sense_resistor: 0.075
 stealthchop_threshold: 0

--- a/config/hardware/axis/Z/TMC/TMC5160_4-Motors.cfg
+++ b/config/hardware/axis/Z/TMC/TMC5160_4-Motors.cfg
@@ -8,5 +8,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.075
+# sense_resistor: 0.075
 stealthchop_threshold: 0

--- a/config/hardware/extruder/TMC/TMC2209.cfg
+++ b/config/hardware/extruder/TMC/TMC2209.cfg
@@ -8,5 +8,5 @@ gcode:
 uart_pin: E_TMCUART
 interpolate: True
 run_current: 0.45
-sense_resistor: 0.110
+# sense_resistor: 0.110
 stealthchop_threshold: 0

--- a/docs/TMC_sense_resistor.md
+++ b/docs/TMC_sense_resistor.md
@@ -1,0 +1,25 @@
+## TMC sense_resistor
+
+> **Warning**:
+>
+> For safety reasons, it is required to configure the `sense_resistor`
+> parameter in your `mcu.cfg` file for each tmc section. This parameter is
+>  crucial for monitoring and protecting your printer's electronics. Ensure
+>  that you set the correct value according to your hardware specifications to
+>  prevent potential damage or hazards.
+
+## Usual sense_resistor values
+Below are the default values used by Klipper. However, your board's values may
+ vary. Please consult the manufacturer documentation of your TMC drivers for
+ the correct values.
+
+| Driver Chip         | Default Sense Resistor |
+|---------------------|------------------------|
+| TMC2208 / TMC2209   | 0.110 Ω                |
+| TMC2130 / TMC5160   | 0.075 Ω                |
+
+For more information, please refer to the [Klipper documentation](https://www.klipper3d.org/Config_Reference.html#tmc-stepper-driver-configuration).
+
+## Adding the sense_resistor to the Configuration
+To add the `sense_resistor` parameter for each stepper, refer to the [override guide](./overrides.md#how-to-write-an-override).
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,14 @@
-# Configuration of Klippain
+# Configuration of Klippain-chocolate
 
 Klippain requires a few simple steps to configure and customize it for your printer: please follow the following documentation step by step in order to get your printer running.
 
   > **Warning**:
   >
   > General rule to keep the auto-update feature working: **never modify Klippain files directly**, but instead add overrides as per the following documentation. To proceed, you can modify all the pre-installed templates in your config root folder (`printer.cfg`, `mcu.cfg`, `variables.cfg` and `overrides.cfg` and, if applicable, the MMU configs files in the `mmu` directory created when you install Happy-Hare) as they will be preserved on update.
+
+  > **Breaking Change**:
+  >
+  > The `sense_resistor` parameter is now mandatory for TMC2208, TMC2209, and TMC5160 drivers in Klippain-chocolate. No default value is provided, so you must set these values in an override. Refer to the [TMC sense_resistor documentation](./TMC_sense_resistor.md) for more details.
 
 ## 1. MCU Settings
 

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -20,6 +20,9 @@ gcode:
     # Dump the MCU version to the console for the Klippy log
     _INIT_MCU_VER
 
+    # Check if all TMC has sense_resistor defined
+    _INIT_CHECK_TMC_SENSE_RESISTOR 
+
     # Check if there is an extruder set
     {% set extruder_enabled = printer["gcode_macro _USER_VARIABLES"].extruder_enabled %}
     {% if not extruder_enabled %}
@@ -125,6 +128,23 @@ gcode:
     {action_respond_info(parameters.output)}
 
 
+
+[gcode_macro _INIT_CHECK_TMC_SENSE_RESISTOR]
+gcode:
+    {% set _errors = [] %}
+    {% for tmc in printer.configfile.config if tmc.startswith("tmc") %}
+        {% set chip, name = tmc.split(' ') %}
+        {% if chip in ['tmc2208', 'tmc2209', 'tmc2130', 'tmc5160'] and printer.configfile.config[tmc].sense_resistor is not defined %}
+            {% set _= _errors.append("`%s`" % tmc) %}
+        {% endif%}
+    {% endfor %}
+    {% if _errors|length %}
+        RESPOND PREFIX="TMC config error:" MSG="<span class="error"--text> sense_resistor MUST but set for <br/>  {
+            _errors|join("<br/>")}<br/> See docs/TMC_sense_resistor.md</span>"
+        _RAISE_ERROR MSG="Configuration error"
+    {% endif %}
+
+
 [gcode_macro _INIT_CHECK_MMU]
 gcode:
     {% if printer.mmu is not defined %}
@@ -143,14 +163,8 @@ gcode:
             SET_GCODE_VARIABLE MACRO=_MMU_SEQUENCE_VARS VARIABLE=travel_speed VALUE={printer["gcode_macro _USER_VARIABLES"].travel_speed}
             SET_GCODE_VARIABLE MACRO=_MMU_SEQUENCE_VARS VARIABLE=lift_speed VALUE={printer["gcode_macro _USER_VARIABLES"].z_drop_speed}
             _MMU_RUN_MARKERS
-        {% elif printer.configfile.settings.mmu.happy_hare_version < 2.5 %}
-            RESPOND PREFIX='Warning:' MSG="<span class="warning"--text> HappyHare <2.5 detected! Your version is deprecated in Klippain and its support will be dropped in the near future. Please update to HappyHare v2.5+</span>"
-            {% if printer['gcode_macro _USER_VARIABLES'].mmu_force_homing_in_start_print is not defined or printer['gcode_macro _USER_VARIABLES'].mmu_unload_on_cancel_print is not defined or printer['gcode_macro _USER_VARIABLES'].mmu_unload_on_end_print is not defined or printer['gcode_macro _USER_VARIABLES'].mmu_check_gates_on_start_print is not defined or printer['gcode_macro _USER_VARIABLES'].mmu_check_errors_on_start_print is not defined %}
-                { action_raise_error("MMU support is enabled in Klippain, but some variables are missing from your variables.cfg. Please update your template or refer to the corresponding documentation: https://github.com/elpopo-eng/klippain-chocolate/blob/main/docs/mmu.md") }
-            {% elif printer["gcode_macro _USER_VARIABLES"].mmu_check_errors_on_start_print and printer.mmu.print_start_detection|int == 1 %}
-                RESPOND MSG="The HappyHare function to automatically detect the start and end of a print has been automatically disabled to allow early detection of an error during the Klippain START_PRINT sequence. This allow a more efficient debugging of the MMU. Refer to the <a href="https://github.com//elpopo-eng/klippain-chocolate/blob/main/docs/mmu.md">Klippain MMU documentation</a>"
-                MMU_TEST_CONFIG print_start_detection=0 # Override this value to disable the HappyHare auto detection of start and end of print in order to call _MMU_PRINT_START and _MMU_PRINT_END manually
-            {% endif %}
+        {% else %}
+            { action_raise_error("Unsupported Happy Hare Version please update to 3.0 minimum") }
         {% endif %}
     {% endif %}
 
@@ -247,6 +261,14 @@ gcode:
 
         SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=startprint_actions_array VALUE="{start_actions_list}"
     {% endif %}
+
+
+# Helper to raise error after console messages were dispatched
+# the part of the macro before _RAISE_ERROR is buffered
+[gcode_macro _RAISE_ERROR]
+gcode:
+    {action_raise_error(params.MSG|default(error))}
+
 
 
 [gcode_macro _INIT_USERCUSTOM]


### PR DESCRIPTION
As Klipper does , the Klippain TMC configuration includes a default sense_resistor value.
However, this is a critical safety feature that users must verify and potentially override, as using incorrect values could lead to hardware damage.  Users must verify and input the correct sense resistor value for their specific board and stepper driver combination.

For instance:

Standard TMC5160: typically uses 0.075 ohms
BTT Kraken: uses 0.022 ohms for some of its stepper drivers
Other boards may use different values

Danger-Klipper/Kalico removed few month ago the default value for `sense_resistor`.

The current PR removes default values and warns users at startup to provide `sense_resistor` values