### PR TITLE
Fix bed center calculation

### DIFF
--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -22,8 +22,8 @@ gcode:
 
     {% set x_position_endstop = printer["configfile"].config["stepper_x"]["position_endstop"]|float %}
     {% set y_position_endstop = printer["configfile"].config["stepper_y"]["position_endstop"]|float %}
-    {% set x_position_center = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
-    {% set y_position_center = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
+    {% set x_position_center = ( printer.toolhead.axis_maximum.x|float + printer.toolhead.axis_minimum.x|float ) /2 %}
+    {% set y_position_center = ( printer.toolhead.axis_maximum.y|float + printer.toolhead.axis_minimum.y|float ) /2 %}
 
 
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -24,6 +24,10 @@ gcode:
     {% set y_position_endstop = printer["configfile"].config["stepper_y"]["position_endstop"]|float %}
     {% set x_position_center = ( printer.toolhead.axis_maximum.x|float + printer.toolhead.axis_minimum.x|float ) /2 %}
     {% set y_position_center = ( printer.toolhead.axis_maximum.y|float + printer.toolhead.axis_minimum.y|float ) /2 %}
+    
+    {% set x_probe_offset = printer.configfile.settings[printer.probe.name].x_offset %}
+    {% set y_probe_offset = printer.configfile.settings[printer.probe.name].y_offset %}
+
 
 
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
@@ -310,10 +314,10 @@ gcode:
             # If there is a bed_mesh enabled and a zero_reference_position set, we retrieve it to home on it
             # Else, we default to the center of the bed
             {% if not bed_mesh_enabled or not printer["configfile"].config["bed_mesh"]["zero_reference_position"] %}
-                G0 X{x_position_center} Y{y_position_center} F{homing_travel_speed}
+                G0 X{x_position_center - x_probe_offset} Y{y_position_center- y_probe_offset} F{homing_travel_speed}
             {% else %}
                 {% set ZRPx, ZRPy = printer["configfile"].config["bed_mesh"]["zero_reference_position"].split(',')|map('trim')|map('float') %}
-                G0 X{ZRPx} Y{ZRPy} F{homing_travel_speed}
+                G0 X{ZRPx - x_probe_offset} Y{ZRPy - y_probe_offset} F{homing_travel_speed}
             {% endif %}
 
         # Else, go to the Z endstop physical pin

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -36,7 +36,8 @@ gcode:
     {% set prime_line_y = params.START_Y|default(prime_line_y)|float %}
     {% set prime_line_direction = params.LINE_DIRECTION|default(printer["gcode_macro _USER_VARIABLES"].prime_line_direction)|string|upper %}
 
-    {% set center_x, center_y = [printer.toolhead.axis_maximum.x / 2, printer.toolhead.axis_maximum.y / 2]|map("float") %}
+    {% set center_x = ( printer.toolhead.axis_maximum.x|float + printer.toolhead.axis_minimum.x|float ) / 2 %}
+    {% set center_y = ( printer.toolhead.axis_maximum.y|float + printer.toolhead.axis_minimum.y|float ) / 2 %}
     
     # If first layer coordinates are retrieved and adaptive mode is enabled, then we replace the coordinates to
     # do an adaptive purge while being careful to have the line stay on the bed when the first layer


### PR DESCRIPTION
This PR fix center bed position for `homing_override` and `primeline` macro

Actual travel area center in homing override is wrong. 
Another way would be to define a variable  `bed_center_xy`

For `probe:virtual_z_endstop` Homing z doesn't take into account probe offset to adjust homing position. The current change fix homing position with probe offset (= to bed center or zero_reference_position)