### PR TITLE
Improve Adaptive primeline

### DIFF
--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -42,10 +42,14 @@ gcode:
     # do an adaptive purge while being careful to have the line stay on the bed when the first layer
     # is in an opposite bed quadrant than the prime line initial coordinates (due to mirrored coordinates from center axes)...
     {% if coordinatesFound and prime_line_adaptive == 1 %}
-        {% set prime_line_x = 2*center_x - prime_line_x if (prime_line_x > center_x and xMaxSpec < center_x) or (prime_line_x < center_x and xMinSpec > center_x) 
-                               else prime_line_x %}
-        {% set prime_line_y = 2*center_y - prime_line_y if (prime_line_y > center_y and yMaxSpec < center_y) or (prime_line_y < center_y and yMinSpec > center_y) 
-                               else prime_line_y %}
+        {% set prime_line_x = 2*center_x - prime_line_x if prime_line_direction == "X" and ((prime_line_x > center_x and xMaxSpec < center_x) or (prime_line_x < center_x and xMinSpec > center_x))
+                                else prime_line_x %}
+        {% set prime_line_y = 2*center_y - prime_line_y if prime_line_direction == "Y" and ((prime_line_y > center_y and yMaxSpec < center_y) or (prime_line_y < center_y and yMinSpec > center_y))
+                                else prime_line_y %}
+        {% if (prime_line_x > xMinSpec - prime_line_margin and prime_line_x < xMaxSpec + prime_line_margin and prime_line_direction == "Y") or
+              (prime_line_y > yMinSpec - prime_line_margin and prime_line_y < yMaxSpec + prime_line_margin and prime_line_direction == "X") %}
+                _RAISE_ERROR MSG="Adaptive_primeline is in exclude object area, unable to Start print, change primeline position or disable adaptive_primeline"
+        {% endif %}
         {% set prime_line_x = [[prime_line_x, xMinSpec - prime_line_margin]|max, xMaxSpec + prime_line_margin]|min %}
         {% set prime_line_y = [[prime_line_y, yMinSpec - prime_line_margin]|max, yMaxSpec + prime_line_margin]|min %}
     {% endif %}

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -2,15 +2,17 @@
 gcode:
 
     # Base macro parameters
-    {% set prime_line_length = params.LINE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_length)|float %}
-    {% set prime_line_purge_distance = params.PURGE_LENGTH|default(printer["gcode_macro _MATERIAL"].current.prime_line_purge_distance)|float %}
-    {% set prime_line_flowrate = params.FLOWRATE|default(printer["gcode_macro _MATERIAL"].current.prime_line_flowrate)|float %}
-    {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|default(0.6)|float %}
-    {% set prime_line_pressure_length = params.LINE_HEIGHT|default(printer["gcode_macro _MATERIAL"].current.prime_line_pressure_length)|default(18)|float %}
+    {% set _material = printer["gcode_macro _MATERIAL"].current %}
+    {% set _uvars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set prime_line_length = params.LINE_LENGTH|default(_uvars.prime_line_length)|float %}
+    {% set prime_line_purge_length = params.PURGE_LENGTH|default(_material.prime_line_purge_length)|float %}
+    {% set prime_line_flowrate = params.FLOWRATE|default(_material.prime_line_flowrate)|float %}
+    {% set prime_line_height = params.LINE_HEIGHT|default(_uvars.prime_line_height)|default(0.6)|float %}
+    {% set prime_line_pressure_length = params.LINE_HEIGHT|default(_material.prime_line_pressure_length)|default(18)|float %}
     {% set prime_line_adaptive = params.ADAPTIVE_MODE|default(1)|int %}
-    {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin)|default(5.0)|float %} # Used only in adaptive mode
-    {% set prime_line_wipe = printer["gcode_macro _USER_VARIABLES"].prime_line_wipe|default(False) %}
-    {% set prime_line_wipe_length = prime_line_length * 0.8 %}
+    {% set prime_line_margin = params.LINE_MARGIN|default(_uvars.prime_line_margin)|default(5.0)|float %} # Used only in adaptive mode
+    {% set prime_line_wipe = _uvars.prime_line_wipe|default(False) %}
+    {% set prime_line_wipe_length = prime_line_length * 0.8 %}    
 
     # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
     {% set coordinatesFound = false %}
@@ -31,10 +33,10 @@ gcode:
     {% endif %}
 
     # We get the default prime line position parameters
-    {% set prime_line_x, prime_line_y = printer["gcode_macro _USER_VARIABLES"].prime_line_xy|map('float') %}
+    {% set prime_line_x, prime_line_y = _uvars.prime_line_xy|map('float') %}
     {% set prime_line_x = params.START_X|default(prime_line_x)|float %}
     {% set prime_line_y = params.START_Y|default(prime_line_y)|float %}
-    {% set prime_line_direction = params.LINE_DIRECTION|default(printer["gcode_macro _USER_VARIABLES"].prime_line_direction)|string|upper %}
+    {% set prime_line_direction = params.LINE_DIRECTION|default(_uvars.prime_line_direction)|string|upper %}
 
     {% set center_x, center_y = [printer.toolhead.axis_maximum.x / 2, printer.toolhead.axis_maximum.y / 2]|map("float") %}
     
@@ -57,32 +59,32 @@ gcode:
     # Choose the way of printing the primeline (in + or -) alongside the direction to avoid going outside the bed boundaries
     {% set prime_line_way = -1 if (prime_line_direction == "X" and prime_line_x > center_x) or (prime_line_direction == "Y" and prime_line_y > center_y) else 1 %}
 
-    {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
-    {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
-    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+    {% set St = _uvars.travel_speed * 60 %}
+    {% set Sz = _uvars.z_drop_speed * 60 %}
+    {% set verbose = _uvars.verbose %}
 
-    {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
-    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
+    {% set klippain_mmu_enabled = _uvars.klippain_mmu_enabled %}
+    {% set filament_sensor_enabled = _uvars.filament_sensor_enabled %}
     {% set re_enable_filament_sensor = 0 %}
 
     {% set max_extrude_cross_section = printer["configfile"].config["extruder"]["max_extrude_cross_section"]|float %}
     {% set filament_diameter = printer["configfile"].config["extruder"]["filament_diameter"]|float %}
     
     # We first compute the width of the prime line
-    {% set purge_volume = prime_line_purge_distance * 3.14159 * (filament_diameter / 2)**2 %}
+    {% set purge_volume = prime_line_purge_length * 3.14159 * (filament_diameter / 2)**2 %}
     {% set line_width = purge_volume / (prime_line_height * prime_line_length) %}
 
     # Then we check that the prime line cross section will not be problematic (exceeding Klipper max_extrude_cross_section)
     # or, if it's the case, we warn the user and add a correction to the length of filament to be purged
     {% if (prime_line_height * line_width) > max_extrude_cross_section %}
         {% if verbose %}
-            {action_respond_info("The prime_line_purge_distance of %.4f mm is too high and will exceed the max_extrude_cross_section!" % prime_line_purge_distance)}
+            {action_respond_info("The prime_line_purge_length of %.4f mm is too high and will exceed the max_extrude_cross_section!" % prime_line_purge_length)}
         {% endif %}
-        {% set prime_line_purge_distance = 0.98 * (max_extrude_cross_section * prime_line_length) / (3.14159 * (filament_diameter / 2)**2) %}
-        {% set purge_volume = prime_line_purge_distance * 3.14159 * (filament_diameter / 2)**2 %}
+        {% set prime_line_purge_length = 0.98 * (max_extrude_cross_section * prime_line_length) / (3.14159 * (filament_diameter / 2)**2) %}
+        {% set purge_volume = prime_line_purge_length * 3.14159 * (filament_diameter / 2)**2 %}
         {% set line_width = purge_volume / (prime_line_height * prime_line_length) %}
         {% if verbose %}
-            {action_respond_info("Klippain corrected the prime_line_purge_distance to %.4f mm" % prime_line_purge_distance)}
+            {action_respond_info("Klippain corrected the prime_line_purge_length to %.4f mm" % prime_line_purge_length)}
         {% endif %}
     {% endif %}
 
@@ -123,12 +125,12 @@ gcode:
     # Prime line
     G92 E0
     {% if prime_line_direction == "X" %}
-        G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
+        G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_length} F{speed}
         {% if prime_line_wipe %}
             G0 X{prime_line_x + prime_line_way*prime_line_wipe_length} F{St}
         {% endif %}
     {% elif prime_line_direction == "Y" %}
-        G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
+        G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_length} F{speed}
         {% if prime_line_wipe %}
             G0 Y{prime_line_y + prime_line_way*prime_line_wipe_length} F{St}
         {% endif %}        
@@ -136,10 +138,7 @@ gcode:
         { action_respond_error("Prime line direction is not valid. Choose either X or Y in the variables.cfg file!") }
     {% endif %}
 
-    # Retract and Z-hop
-    G92 E0
-    G1 E-0.2 F2100
-    G92 E0
+    # Z-hop
     G1 Z3 F{Sz}
 
     # Additional small movement to get out of the line as some slicers directly emmit
@@ -149,7 +148,7 @@ gcode:
     G90
     
     # Flushing Klipper's buffer to ensure the primeline sequence is done before continuing
-    M400
+    # M400 #Flushing Klipper's buffer let printer doing a small pause and let the nozzle ooze
 
     {% if klippain_mmu_enabled %}
         _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={printer.mmu.clog_detection}

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -46,8 +46,8 @@ gcode:
                                 else prime_line_x %}
         {% set prime_line_y = 2*center_y - prime_line_y if prime_line_direction == "Y" and ((prime_line_y > center_y and yMaxSpec < center_y) or (prime_line_y < center_y and yMinSpec > center_y))
                                 else prime_line_y %}
-        {% if (prime_line_x > xMinSpec - prime_line_margin and prime_line_x < xMaxSpec + prime_line_margin and prime_line_direction == "Y") or
-              (prime_line_y > yMinSpec - prime_line_margin and prime_line_y < yMaxSpec + prime_line_margin and prime_line_direction == "X") %}
+        {% if (prime_line_x > xMinSpec - prime_line_margin and prime_line_x < xMaxSpec + prime_line_margin) or
+              (prime_line_y > yMinSpec - prime_line_margin and prime_line_y < yMaxSpec + prime_line_margin) %}
                 _RAISE_ERROR MSG="Adaptive_primeline is in exclude object area, unable to Start print, change primeline position or disable adaptive_primeline"
         {% endif %}
         {% set prime_line_x = [[prime_line_x, xMinSpec - prime_line_margin]|max, xMaxSpec + prime_line_margin]|min %}


### PR DESCRIPTION
I usually place primeline at the opposite of park position (eg. front or right if park is rear left), to avoid crossing primeline during pause/color change/... . 

Adaptive primeline changes the position if object are not in the same quadrant. 

The current proposal adjust only primeline direction but stay in side of configured position.

The module also throw an error in prime line is in FL_SIZE/cancel_object area . 