### PR TITLE
Lock start_print if startup failed

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -87,6 +87,11 @@ gcode:
         {% set material = printer["gcode_macro _USER_VARIABLES"].material_parameters[MATERIAL] %}
     {% endif %}
     
+    {% set _u_vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% if not _u_vars.klippain_startup_succeded %}
+        {action_raise_error("Klippain failed to accomplish startup, solves your issues before using the printer")}
+    {% endif %}
+    
     # --------------------------------
     # Let's do the START_PRINT actions
     # --------------------------------

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -6,6 +6,11 @@ initial_duration: 1
 gcode:
     _KLIPPAIN_STARTUP
 
+# declare startprint_actions_array
+[gcode_macro _USER_VARIABLES]
+variable_klippain_startup_succeded: False
+gcode:
+
 
 [gcode_macro _KLIPPAIN_STARTUP]
 gcode:
@@ -64,6 +69,7 @@ gcode:
         RESPOND MSG="Klippain started and ready!"
     {% endif %}
 
+    SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=klippain_startup_succeded VALUE=True
 
 [gcode_macro _INIT_LEDS]
 gcode:


### PR DESCRIPTION
When something goes wrong during startup the macro _KLIPPAIN_STARTUP fails to populate startprint_action_array.

This proposal locks the START_PRINT to avoid unpredictable behavior if  _KLIPPAIN_STARTUP has failed.

Thanks.