### PR TITLE
Revert M400 remove

### DIFF
--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -123,6 +123,8 @@ gcode:
     G92 E0
     G1 E{prime_line_pressure_length} F150
 
+    M400 # flush buffer before prime to ensure filament sensor is enables and avoid oozing
+
     # Prime line
     G92 E0
     {% if prime_line_direction == "X" %}


### PR DESCRIPTION
The previous PR https://github.com/elpopo-eng/klippain-chocolate/pull/23 removed M400 to prevent oozing after the primeline.
However, M400 is required for SET_FILAMENT_SENSOR to function correctly.

This PR places flush command right before primeline extrusion to fix filament_sensor behavior and to keep the "oozing fix"

Thanks.