### PR TITLE
Add _BUILDPLATE z_offset support

### DIFF
--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -58,10 +58,12 @@ resolution: 0.1
 [include ../macros/helpers/filament_swap.cfg]
 [include ../macros/helpers/heatsoak.cfg]
 [include ../macros/helpers/material_presets.cfg]
+[include ../macros/helpers/buildplate_presets.cfg]
 [include ../macros/helpers/prime_line.cfg]
 [include ../macros/helpers/nozzle_cleaning.cfg]
 [include ../macros/helpers/temp_check.cfg]
 
+[include ../macros/miscs/presets_manager.cfg]
 [include ../macros/miscs/compatibility.cfg]
 [include ../macros/miscs/debugging.cfg]
 [include ../macros/miscs/prompt.cfg]

--- a/docs/materials_management.md
+++ b/docs/materials_management.md
@@ -1,6 +1,14 @@
 ## Materials Presets Management in Klippain-Chocolate
 
-Klippain's `START_PRINT` macro, adjusts printer behavior based on material presets.
+Klippain Chocolate's `START_PRINT` macro, is able to adjust printer behavior based on material presets.
+
+> [!NOTE]
+The following `_USER_VARIABLES` parameters are not used anymore and transfered to `gcode_macro _MATERIAL` array : 
+`purge_length`,
+`standby_retract_length`, `purge_speed`, `retract_length`, `unretract_length`, `prime_line_flowrate`,
+`prime_line_pressure_length`
+
+If existing, `material_parameters` is migrated into the material array in the save_variables file.
 
 ### Default Material Settings
 
@@ -32,5 +40,5 @@ Material references are passed from the slicer to the printer via the `start_gco
 
 - `SET_MATERIAL`: Add or modify material parameters. If the `NAME` parameter is not provided, it will modify the current material. A prompt will ask if you want to retain the values across restarts. The new material will inherit default settings for any unspecified parameters.
 - `REMOVE_MATERIAL`: Delete the material. If the `NAME` parameter is not provided, it will delete the current material. A prompt will ask if you want to permanently remove the material across restarts.
-- `SELECT_MATERIAL`: Choose material settings from list. This macro is a UI helper and MUST NOT be used inside `START_PRINT`. 
+- `SELECT_MATERIAL`: Choose material settings from list. This macro is a UI helper and **MUST NOT** be used inside `START_PRINT`. 
 

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -46,6 +46,7 @@ gcode:
     # Set the variables to be used in all the modules based on the slicer parameters
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=bed_temp VALUE={BED_TEMP}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=extruder_temp VALUE={EXTRUDER_TEMP}
+    SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=z_adjust VALUE={Z_ADJUST}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=soak VALUE={SOAK}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=chamber_temp VALUE={CHAMBER_TEMP}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=chamber_maxtime VALUE={CHAMBER_MAXTIME}
@@ -63,51 +64,40 @@ gcode:
         SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=total_layer VALUE={params.TOTAL_LAYER|int}
     {% endif %}
 
-    # Get all the config options and configurations for this macro
-    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
-    {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set light_intensity_start_print = printer["gcode_macro _USER_VARIABLES"].light_intensity_start_print %}
-    {% set light_intensity_printing = printer["gcode_macro _USER_VARIABLES"].light_intensity_printing %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
-    {% set force_homing_in_start_print = printer["gcode_macro _USER_VARIABLES"].force_homing_in_start_print %}
-    {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
-    {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
-    {% set firmware_retraction_enabled = printer["gcode_macro _USER_VARIABLES"].firmware_retraction_enabled %}
-    {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
-    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
-    {% set part_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].part_fan_tach_enabled %}
-    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled %}
+    _LOAD_PROFILE_BY_NAME TABLE=material NAME='{MATERIAL}'
+    _DO_START_PRINT {rawparams}
 
-    {% if MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
-        RESPOND MSG="Material '{MATERIAL}' is unknown!"
-        { action_raise_error("Use SET_MATERIAL macro to add this new material! (%s)" % (MATERIAL)) }
-    {% else %}
-        _LOAD_MATERIAL NAME='{MATERIAL}'
+[gcode_macro _DO_START_PRINT]
+gcode:
+    # Get all the config options and configurations for this macro
+    {% set _sp = printer["gcode_macro START_PRINT"]%}
+    {% set _uvars = printer["gcode_macro _USER_VARIABLES"] %}
+
         #set curent material parameters
-        {% set material = printer["gcode_macro _USER_VARIABLES"].material_parameters[MATERIAL] %}
-    {% endif %}
+    {% set material = printer["gcode_macro _MATERIAL"].current %}
+    {% set buildplate = printer["gcode_macro _BUILDPLATE"].current|default({'z_offset':0}) %}
     
     # --------------------------------
     # Let's do the START_PRINT actions
     # --------------------------------
-    {% if status_leds_enabled %}
+    {% if _uvars.status_leds_enabled %}
         STATUS_LEDS COLOR="BUSY"
     {% endif %}
 
-    {% if light_enabled %}
-        LIGHT_ON S={light_intensity_start_print}
+    {% if _uvars.light_enabled %}
+        LIGHT_ON S={_uvars.light_intensity_start_print}
     {% endif %}
 
     CLEAR_PAUSE
 
-    {% if bed_mesh_enabled %}
+    {% if _uvars.bed_mesh_enabled %}
         BED_MESH_CLEAR
     {% endif %}
 
     # If a filter is enabled and already running due to a print that just finished, we stop
     # it now and deactivate the pending delayed gcode that could be running. The filter
     # could be restarted later in the START_PRINT sequence depending of the parameters
-    {% if filter_enabled %}
+    {% if _uvars.filter_enabled %}
         UPDATE_DELAYED_GCODE ID=_STOP_FILTER_DELAYED DURATION=0
         START_FILTER SPEED={material.filter_speed / 100}
     {% endif %}
@@ -115,13 +105,13 @@ gcode:
     # If a tachometer is enabled on one of the fans, we check them:
     #   - It's done only once for the part fan to be sure nothing block it before starting the print
     #   - And as a safety feature, we start a monitoring loop for the hotend fan (that is automatically stopped at the end of a print)
-    {% if part_fan_tach_enabled %}
+    {% if _uvars.part_fan_tach_enabled %}
         M106 S255
         G4 P2000
         _PART_FAN_CHECK
         M106 S0
     {% endif %}
-    {% if hotend_fan_tach_enabled %}
+    {% if _uvars.hotend_fan_tach_enabled %}
         UPDATE_DELAYED_GCODE ID=_BACKGROUND_HOTEND_TACHO_CHECK DURATION=1
     {% endif %}
 
@@ -132,13 +122,13 @@ gcode:
     M83
 
     # Material parameters
-    {% if firmware_retraction_enabled %}
+    {% if _uvars.firmware_retraction_enabled %}
         SET_RETRACTION RETRACT_LENGTH={material.retract_length} RETRACT_SPEED={material.retract_speed} UNRETRACT_EXTRA_LENGTH={material.unretract_extra_length} UNRETRACT_SPEED={material.unretract_speed}
     {% endif %}
     SET_PRESSURE_ADVANCE ADVANCE={material.pressure_advance} SMOOTH_TIME={material.pressure_advance_smooth_time}
 
     # Homing before START_PRINT movements and actions
-    {% if force_homing_in_start_print %}
+    {% if _uvars.force_homing_in_start_print %}
         G28
     {% else %}
         _CG28
@@ -147,7 +137,7 @@ gcode:
 
     # Here is the core of the START_PRINT were we get the startprint_actions variable
     # to do the procedure in the correct order for the configured probe (or user custom override)
-    {% set sp_actions = printer["gcode_macro _USER_VARIABLES"].startprint_actions_array %}
+    {% set sp_actions = _uvars.startprint_actions_array %}
     {% for action in sp_actions %}
         {% if action.module %}
              _MODULE_{action.module}
@@ -169,23 +159,23 @@ gcode:
 
     # Fine adjustement of z offset (from the slicer profile). This is used to do a custom adjustement
     # when using textured/smooth PEI sheets, or for a special material from the slicer, etc...
-    SET_GCODE_OFFSET Z_ADJUST={Z_ADJUST + material.additional_z_offset} MOVE=1
+    SET_GCODE_OFFSET Z_ADJUST={_sp.z_adjust + material.additional_z_offset + buildplate.z_offset} MOVE=1
 
     # Final material parameters
-    {% if filament_sensor_enabled %}
+    {% if _uvars.filament_sensor_enabled %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE={material.filament_sensor}
     {% endif %}
 
     # And.... Goooo!
-    {% if status_leds_enabled %}
+    {% if _uvars.status_leds_enabled %}
         STATUS_LEDS COLOR="PRINTING"
     {% endif %}
 
-    {% if light_enabled %}
-        LIGHT_ON S={light_intensity_printing}
+    {% if _uvars.light_enabled %}
+        LIGHT_ON S={_uvars.light_intensity_printing}
     {% endif %}
 
-    {% if verbose %}
+    {% if _uvars.verbose %}
         RESPOND MSG="Start printing !"
     {% endif %}
 

--- a/macros/helpers/buildplate_presets.cfg
+++ b/macros/helpers/buildplate_presets.cfg
@@ -1,0 +1,52 @@
+## Macros to manage buildplate offsets
+[gcode_macro _BUILDPLATE]
+variable_default: {"z_offset":0}
+variable_current: {}
+gcode:
+
+
+### MACROS ###
+[gcode_macro SET_BUILDPLATE]
+description: Add/Set builplate to config, if a parameter is empty it will use the default value
+gcode:
+    {% set _ = params.NAME %}
+#######################################################################
+## Declare entry params Only for GUI (Fluidd/Mainsail/Klipperscreen) ##
+## Entries must correspond to the variable_default keys
+
+    {% set _ = params.Z_OFFSET %}
+
+#######################################################################
+    _SET_PROFILE TABLE="buildplate" {rawparams}
+
+
+# Select a buildplate from list, to use in UI not in macros
+[gcode_macro SELECT_BUILDPLATE]
+description: Select a buildplate offset from list
+gcode:
+ ## load settings table or throw error if save variable not set
+    {% set _buildplates=printer.save_variables.variables.buildplate_table|default({}) %}
+
+    {% if _buildplates|length %}
+        {% set options=[] %}
+        {% set values=[] %}
+        {% set colors=[] %}
+        {% for name, datas in _buildplates.items() %}
+            {% set z_offset=datas.z_offset|default(printer["gcode_macro _BUILDPLATE"].default.z_offset)%}
+            {% set _= options.append("%s: %smm" % (name,z_offset)) %}
+            {% set _= values.append(name) %}
+            {% set _= colors.append("secondary")%}
+        {% endfor %}
+        _PROMPT_SELECT TITLE="Select a buildplate" MSG="Choose a buildplate to apply offset at START_PRINT" OPTIONS="{ options|join(",")
+        }" VALUES="{ values|join(",") }" COLORS="{ colors|join(",") }" ACTION="_LOAD_PROFILE_BY_NAME TABLE=buildplate" KEY=NAME
+    {% else %}
+        RESPOND TYPE=error MSG="No buildplate. Use SET_BUILDPLATE"
+        _PROMPT_MSGBOX MSG="No buildplate in buildplate_table. Use SET_BUILDPLATE to set one"
+    {% endif %}     
+
+[gcode_macro REMOVE_BUILDPLATE]
+description: Remove an item from buildplate_table
+gcode:
+    {% set _= params.NAME %}
+    _REMOVE_PROFILE TABLE=buildplate {rawparams}
+    

--- a/macros/helpers/material_presets.cfg
+++ b/macros/helpers/material_presets.cfg
@@ -3,7 +3,7 @@
 
 # This config file contains macros that are used in conjuction with material settings
 [gcode_macro _MATERIAL]
-variable_default: {  
+variable_default: {
         "pressure_advance": 0.048,
         "pressure_advance_smooth_time": 0.015,
         "retract_length": 0.5,
@@ -23,8 +23,7 @@ variable_default: {
         "purge_speed": 2.5,                 # Speed to purge (in mm/s)
         "purge_length": 30,                 # Amount to purge (in mm)
     }
-variable_current: {  
-    }    
+variable_current: {}    
 gcode:
 
 ### MACROS ###
@@ -53,171 +52,58 @@ gcode:
     {% set _ = params.PRIME_LINE_FLOWRATE %}
     {% set _ = params.PURGE_SPEED %}
     {% set _ = params.PURGE_LENGTH %}
-#######################################################################
-    _SET_MATERIAL {rawparams}
+ #######################################################################
+    _SET_PROFILE TABLE=material {rawparams}
 
-# variable kept for backward compatibility
-[gcode_macro _USER_VARIABLES]
-variable_material_parameters: {}
 
 # Remove a material from the material_table
 [gcode_macro REMOVE_MATERIAL]
 description: Remove material from config
 gcode:
-    {% set _p = params %}   
-    {% set fs_table= printer["gcode_macro _USER_VARIABLES"].material_parameters%}
-    {% set NAME = params.NAME|default(printer.save_variables.variables.current_material_name) %}
-    
-    {% if _p.CONFIRM == "1" %}
-        _PROMPT_CLOSE
-        {% if NAME|length %}
-            {% if fs_table[NAME] %}
-                {% set _= fs_table.pop(NAME) %}
-                SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE='{ fs_table|tojson }'
-                _SAVE_MATERIAL_PROFILES
-                _RESTORE_LAST_USED_MATERIAL
-            {% else %}
-                {action_raise_error("Material '%s' not found" % NAME)}
-            {% endif %}
-        {% else %}
-            {action_raise_error("No material specified")}
-        {% endif %}
-    {% else %}
-        _PROMPT_QUESTION TITLE="Remove Material" MSG="Are you sure you want to remove '{NAME}' permanently ?" ACTION="REMOVE_MATERIAL NAME=\\\"{NAME}\\\" CONFIRM=1"
-    {% endif %}
+    _REMOVE_PROFILE TABLE=material {rawparams}
+
 
 # Reset material_table
 [gcode_macro RESET_MATERIALS]
-description: Reset material_table
+description: Reset material_table from material parameters
 gcode:
     {% set _p = params %}
-    {% set fs_table = printer.configfile.config["gcode_macro _USER_VARIABLES"].variable_material_parameters|replace('\n','')  %}
+    {% set fs_table = printer["gcode_macro _USER_VARIABLES"].material_parameters|default({}) %}
+    {% set default = printer["gcode_macro _MATERIAL"].default %}
     
-    {% if _p.CONFIRM == "1" %}
-        _PROMPT_CLOSE
-        {% if fs_table|length %}
-            SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE="{ fs_table }"
-            _SAVE_MATERIAL_PROFILES
-            _LOAD_MATERIAL_PROFILES
-            _RESTORE_LAST_USED_MATERIAL
+    {% if fs_table|length %}
+        {% if _p.CONFIRM == "1" %}
+            _PROMPT_CLOSE
+            # clear current material table
+            SAVE_VARIABLE VARIABLE=material_table VALUE='{{}}'
+            {% for name, settings in fs_table.items() %}
+                _SET_PROFILE TABLE=material NAME='{name}'{% for parameter, value in settings.items() 
+                %} {parameter|upper}={value}{% endfor %}
+            {% endfor %}
         {% else %}
-            {action_raise_error("No materials found in configfile")}
+            _PROMPT_QUESTION TITLE="Reset Material settings" MSG="Are you sure you want to reset material_table ? All changes in material_table will be erased" ACTION="RESET_MATERIALS CONFIRM=1"
         {% endif %}
     {% else %}
-        _PROMPT_QUESTION TITLE="Reset Material settings" MSG="Are you sure you want to reset material_table ? All changes in material_table will be erased" ACTION="RESET_MATERIALS CONFIRM=1"
+        {action_raise_error("No materials found in configfile")}
     {% endif %}
 
+
+# Select Material from list, to use in UI not in macros
 [gcode_macro SELECT_MATERIAL]
 description: Select a material from list
 gcode:
-    {% set fs_table= printer["gcode_macro _USER_VARIABLES"].material_parameters%}
-        
+    {% set fs_table= printer.save_variables.variables.material_table %}
+
+    {% if fs_table|length %}    
     _PROMPT_SELECT TITLE="Select material" MSG="Load parameters for : " OPTIONS="{ fs_table.keys()|join(',')
-        }" ACTION="_LOAD_MATERIAL" KEY=NAME
+        }" ACTION="_LOAD_PROFILE_BY_NAME TABLE=material" KEY=NAME
+    {% else %}
+        RESPOND TYPE=error MSG="No Material. Use SET_MATERIAL"
+        _PROMPT_MSGBOX MSG="No material in material_table. Use SET_MATERIAL to set one"
+    {% endif %}
 
 
 ### BACKEND ###
-# Load material settings from the material_table
-[gcode_macro _LOAD_MATERIAL]
-description: Load material settings
-gcode:
-    {% set _p = params %}
-    {% set fs_table= printer["gcode_macro _USER_VARIABLES"].material_parameters %}
-    {% set NAME = params.NAME|default("") %}
-    
-    _PROMPT_CLOSE
-    {% if NAME|length %}
-        {% if fs_table[NAME] %}
-            RESPOND MSG="Material '{NAME}' is used"
-            SAVE_VARIABLE VARIABLE=current_material_name value='"{NAME}"'
-            _RESTORE_LAST_USED_MATERIAL
-        {% else %}
-            RESPOND MSG="Material '{MATERIAL}' is unknown!"
-            { action_raise_error("Use SET_MATERIAL macro to add this new material! (%s)" % NAME) }
-        {% endif %}
-    {% else %}
-        {action_raise_error("No material specified") }
-    {% endif %}
-
-# Records the material settings in the material_table
-[gcode_macro _SET_MATERIAL]
-description: Set material settings
-gcode:
-
-    {% set _p=params %}
-## remove empty parameters (Fluidd hack)
-    {% for param in _p.copy() if _p[param] == "" %}
-        {% set _= _p.pop(param) %}
-    {% endfor %}
-
-## load variables
-    {% set fs_table = printer["gcode_macro _USER_VARIABLES"].material_parameters%}
-    {% set NAME = _p.NAME|default(printer.save_variables.variables.current_material_name) %}
-    {% set default = printer["gcode_macro _MATERIAL"].default %}
-##  
-    {% if NAME|length %}
-        {% if not fs_table[NAME] %}
-            {% set _= fs_table.update({NAME:default}) %}
-        {% endif %}
-        {% for param, value in _p.items() if param | lower in default %}
-            {% set _= fs_table[NAME].update({param|lower :
-                value|int if (value|float == value|int and value|float != 0.0) or value == '0' else (
-                value|float if value|float != 0.0 else 
-                value|string
-                )}) %}
-        {% endfor %}
-        SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE='{ fs_table|tojson }'
-        # Apply changes to current material array
-        _RESTORE_LAST_USED_MATERIAL
-        _PROMPT_QUESTION TITLE="Save Material settings" MSG="Do you want to keep the settings for {NAME} accross restarts ?" ACTION="_SAVE_MATERIAL_PROFILES"
-    {% else %}
-        {action_raise_error("No settings to apply, NAME is empty")}
-    {% endif %}
-
-# Load material settings from the material_table
-[gcode_macro _LOAD_MATERIAL_PROFILES]
-description: Load material settings from the material_table
-gcode:
-    {% set fs_table = printer.save_variables.variables.material_table | default({}) %}
-    {% set default = printer["gcode_macro _MATERIAL"].default %}
-    {% if fs_table|length > 0 %}
-        {% for name, settings in fs_table.items() %}
-            # Add missing parameters from default
-            {% for parameter in default if parameter not in settings %}
-                {% set _=fs_table[name].update( {parameter:default[parameter]} ) %}
-            {% endfor %}
-        {% endfor %}
-        SET_GCODE_VARIABLE MACRO=_USER_VARIABLES VARIABLE=material_parameters VALUE='{ fs_table|tojson }'
-    {% else %}
-        {action_raise_error("No materials found in material_table")}
-    {% endif %}
-
-# Save material settings to the material_table
-[gcode_macro _SAVE_MATERIAL_PROFILES]
-description: Save material settings to the material_table
-gcode:
-    {% set fs_table = printer["gcode_macro _USER_VARIABLES"].material_parameters | default({}) %}
-    {% set default = printer["gcode_macro _MATERIAL"].default %}
-    {% set toremove={}%}
-   
-    _PROMPT_CLOSE
-    {% if fs_table|length %}
-        {% for name, settings in fs_table.copy().items() %}
-            # Remove parameters that are the same as the default
-            {% for parameter in default 
-                if settings[parameter] == default[parameter] %}
-                {% set _=fs_table[name].pop(parameter) %}
-            {% endfor %}
-            # Remove parameters that are not in default
-            {% for parameter in settings.copy() if parameter not in default %}
-                {% set _=fs_table[name].pop(parameter) %}
-            {% endfor %}
-        {% endfor %}
-        SAVE_VARIABLE VARIABLE=material_table value='{ fs_table|tojson }'
-    {% else %}
-        {action_raise_error("No material settings found in material_parameters")}
-    {% endif %}
-
 ### BACKWARD COMPATIBILITY
 # Migrate config Apply the material, could be removed in a future release
 [gcode_macro _MIGRATE_MATERIAL_SETTINGS]
@@ -225,23 +111,8 @@ gcode:
     {% set fs_table = printer.save_variables.variables.material_table | default({}) %}
     {% if fs_table|length == 0 %}
         ## Migrate old material_parameters to material_table in save_variables
-        _SAVE_MATERIAL_PROFILES
+        SAVE_VARIABLE VARIABLE=current_material_name value='""'
+        RESET_MATERIALS CONFIRM=1
         RESPOND TYPE=error MSG="_USER_VARIABLES material_parameters are now stored into Save_variables !"
         RESPOND TYPE=echo MSG="Use SET_MATERIAL to add or edit a material"
-    {% endif %}
-
-
-# Restore last used material 
-[gcode_macro _RESTORE_LAST_USED_MATERIAL]
-description: Restore last used material
-gcode:
-    {% set material_name = printer.save_variables.variables.current_material_name %}
-    {% if material_name %}
-        {% set current = printer["gcode_macro _USER_VARIABLES"].material_parameters[material_name] | default("") %}
-        {% if current|length %}
-            SET_GCODE_VARIABLE MACRO=_MATERIAL VARIABLE=current VALUE='{ current|tojson }'
-        {% else %}
-            RESPOND TYPE=error  MSG="Material '{material_name}' is unknown!"
-            RESPOND TYPE=error  MSG="Use SET_MATERIAL macro to add this new material!"
-        {% endif %}
     {% endif %}

--- a/macros/helpers/material_presets.cfg
+++ b/macros/helpers/material_presets.cfg
@@ -98,8 +98,8 @@ gcode:
     _PROMPT_SELECT TITLE="Select material" MSG="Load parameters for : " OPTIONS="{ fs_table.keys()|join(',')
         }" ACTION="_LOAD_PROFILE_BY_NAME TABLE=material" KEY=NAME
     {% else %}
-        RESPOND TYPE=error MSG="No Material. Use SET_MATERIAL"
         _PROMPT_MSGBOX MSG="No material in material_table. Use SET_MATERIAL to set one"
+        _RAISE_ERROR MSG="No Material. Use SET_MATERIAL"
     {% endif %}
 
 

--- a/macros/miscs/presets_manager.cfg
+++ b/macros/miscs/presets_manager.cfg
@@ -105,23 +105,35 @@ gcode:
             # store current profile name accross restarts 
             SAVE_VARIABLE VARIABLE={"current_%s_name" % table_name} VALUE='"{name}"'
             SET_GCODE_VARIABLE MACRO=_{table_name|upper} VARIABLE=current value='{ _table[name]|tojson }'
-           {% set _= output_str.append("Loaded %s: %s" % (table_name, name)) %}
-
-            {% for k,v in _table[name].items() %}
-                {% set _= output_str.append("-%s%s : %s" % (k,' (default)' if v == default[k] else '',v)) %}
-            {% endfor %}
-            { action_respond_info(output_str|join('\n')) }
+            { action_respond_info("Loaded %s: %s" % (table_name, name)) }
 
         # Load default parameters if no profile is selected
         {% elif name == '' %}
             SET_GCODE_VARIABLE MACRO=_{table_name|upper} VARIABLE=current value='{ default|tojson }'
-            RESPOND TYPE=command MSG="{"Default %s parameters loaded" % table_name }"
+            RESPOND TYPE=command MSG="Default {table_name} parameters loaded"
 
         # Error if name not in table
         {% else %}
             RESPOND TYPE=error  MSG="{table_name|capitalize} '{name}' is unknown!"
             RESPOND TYPE=error  MSG="Use SET_{table_name|upper} macro to add this new {table_name}!"
-            _RAISE_ERROR MSG="{"Unable to load %s from %s" % (name,table_name) }"
+            _RAISE_ERROR MSG="Unable to load {name} from {table_name}"
 
         {% endif %}
+    {% endif %}
+
+[gcode_macro _SHOW_CURRENT_PROFILE]
+gcode:
+    {% set _p=params %}
+    {% set table_name = _p.TABLE|lower|default('') %}
+    {% set output_str=[] %}
+
+    {% if printer["gcode_macro _%s" % table_name|upper] is defined %}
+        {% set name=printer.save_variables.variables["current_%s_name" % table_name]|default('') %}
+        {% set default = printer["gcode_macro _%s" % table_name|upper].default %}
+        {% set current = printer["gcode_macro _%s" % table_name|upper].current %}
+        {% set _= output_str.append("Current %s: %s" % (table_name, name)) %}
+        {% for k,v in current.items() %}
+            {% set _= output_str.append("-%s%s : %s" % (k,' (default)' if v == default[k] else '',v)) %}
+        {% endfor %}
+        { action_respond_info(output_str|join('\n')) }
     {% endif %}

--- a/macros/miscs/presets_manager.cfg
+++ b/macros/miscs/presets_manager.cfg
@@ -88,7 +88,6 @@ description: Load current table entry in a variable
 gcode:
     {% set _p=params %}
     {% set table_name = _p.TABLE|lower|default('') %}
-    {% set default=printer["gcode_macro _%s" % table_name|upper].default %}
     {% set output_str=[] %}
 
     {% if printer["gcode_macro _%s" % table_name|upper] is defined %}
@@ -122,7 +121,7 @@ gcode:
         {% else %}
             RESPOND TYPE=error  MSG="{table_name|capitalize} '{name}' is unknown!"
             RESPOND TYPE=error  MSG="Use SET_{table_name|upper} macro to add this new {table_name}!"
-            _RAISE_ERROR MSG="{"Unable to load %s from %s" % (name,table_name)) }"
+            _RAISE_ERROR MSG="{"Unable to load %s from %s" % (name,table_name) }"
 
         {% endif %}
     {% endif %}

--- a/macros/miscs/presets_manager.cfg
+++ b/macros/miscs/presets_manager.cfg
@@ -1,0 +1,128 @@
+#### Backend macros to manage material, buildplate profiles ...
+##
+[gcode_macro _SET_PROFILE]
+description: Add or edit a table entry
+gcode:
+    {% set _p=params %}
+    ## remove empty parameters (Fluidd hack)
+    {% for param in _p.copy() if _p[param] == "" %}
+        {% set _= _p.pop(param) %}
+    {% endfor %}
+
+    {% set table_name = _p.TABLE|lower|default('') %}
+    {% if printer["gcode_macro _%s" % table_name|upper] is defined %}
+        # Load table by name
+        {% set _table=printer.save_variables.variables["%s_table" % table_name]|default({}) %}
+        # get current_name vs name
+        {% set current_name=printer.save_variables.variables["current_%s_name" % table_name] %}
+        {% set name=_p.NAME|default(current_name) %}
+        # get default and current array
+        {% set default = printer["gcode_macro _%s" % table_name|upper].default %}
+        {% set current = printer["gcode_macro _%s" % table_name|upper].current %}
+        
+        {% if name|length %}
+            # Create new table entry
+            {% if not _table[name] %}
+                {% set _= _table.update({name:{}}) %}
+            {% endif %}
+            # Update values
+            {% for param, value in _p.items() if param|lower in default %}
+                # hack to apply type to `value`
+                {% set value = value|int if (value|float == value|int and value|float != 0.0) or value == '0' else (
+                        value|float if value|float != 0.0 else 
+                        value|string
+                        )%}
+                {% if not value == default[param|lower] %}
+                    {% set _= _table[name].update({param|lower : value}) %}
+                {% endif %}
+            {% endfor %}
+            SAVE_VARIABLE VARIABLE={table_name}_table VALUE='{ _table|tojson }'
+            # if modified profile is current, reload with new settings
+            {% if name == current_name %}
+                _LOAD_PROFILE_BY_NAME TABLE={table_name} NAME={NAME}
+            {% endif %}   
+        {% else %}
+            {action_raise_error("No settings to apply, NAME is empty")}
+        {% endif %}
+    {% endif %}
+
+[gcode_macro _REMOVE_PROFILE]
+description: Remove a profile from the table
+gcode:
+    {% set _p = params %} 
+    {% set table_name = _p.TABLE|lower|default('') %}
+    {% if printer["gcode_macro _%s" % table_name|upper] is defined %}
+        # Load table by name
+        {% set _table=printer.save_variables.variables["%s_table" % table_name]|default({}) %}
+        # get current_name vs name
+        {% set current_name=printer.save_variables.variables["current_%s_name" % table_name] %}
+        {% set name = _p.NAME|default(current_name)|default('') %}
+        
+        {% if _p.CONFIRM != "1" %}
+            # Ask to confirm
+            _PROMPT_QUESTION TITLE="Remove - {table_name}" MSG="Are you sure you want to remove '{name
+                }' permanently ?" ACTION="_REMOVE_PROFILE TABLE={table_name} NAME='{name}' CONFIRM=1"
+        {% else %}
+            _PROMPT_CLOSE
+            {% if name|length %}
+                {% if _table[name] is defined %}
+                    # remove table item
+                    {% set _= _table.pop(name) %}
+                    SAVE_VARIABLE VARIABLE={table_name}_table VALUE='{ _table|tojson }'
+                    {% if name == current_name %}
+                        SET_GCODE_VARIABLE MACRO=_{table_name|upper} VARIABLE=current value='{ {}|tojson }'
+                        SAVE_VARIABLE VARIABLE={"current_%s_name" % table_name} VALUE='""' 
+                    {% endif %}
+                {% else %}
+                    {action_raise_error("%s '%s' not found" % (table_name,name))}
+                {% endif %}
+            {% else %}
+                {action_raise_error("No %s specified" % table_name)}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+
+
+[gcode_macro _LOAD_PROFILE_BY_NAME]
+description: Load current table entry in a variable
+gcode:
+    {% set _p=params %}
+    {% set table_name = _p.TABLE|lower|default('') %}
+    {% set default=printer["gcode_macro _%s" % table_name|upper].default %}
+    {% set output_str=[] %}
+
+    {% if printer["gcode_macro _%s" % table_name|upper] is defined %}
+        {% set _table=printer.save_variables.variables["%s_table" % table_name]|default({}) %}
+        {% set default = printer["gcode_macro _%s" % table_name|upper].default %}
+        {% set name=_p.NAME|default(printer.save_variables.variables["current_%s_name" % table_name])|default('') %}
+
+        _PROMPT_CLOSE
+        # Load profile
+        {% if _table[name] is defined %}
+            # complete with default value if parameter is missing
+            {% for parameter in default if parameter not in _table[name] %}
+                {% set _=_table[name].update( {parameter:default[parameter]} ) %}
+            {% endfor %}
+            # store current profile name accross restarts 
+            SAVE_VARIABLE VARIABLE={"current_%s_name" % table_name} VALUE='"{name}"'
+            SET_GCODE_VARIABLE MACRO=_{table_name|upper} VARIABLE=current value='{ _table[name]|tojson }'
+           {% set _= output_str.append("Loaded %s: %s" % (table_name, name)) %}
+
+            {% for k,v in _table[name].items() %}
+                {% set _= output_str.append("-%s%s : %s" % (k,' (default)' if v == default[k] else '',v)) %}
+            {% endfor %}
+            { action_respond_info(output_str|join('\n')) }
+
+        # Load default parameters if no profile is selected
+        {% elif name == '' %}
+            SET_GCODE_VARIABLE MACRO=_{table_name|upper} VARIABLE=current value='{ default|tojson }'
+            RESPOND TYPE=command MSG="{"Default %s parameters loaded" % table_name }"
+
+        # Error if name not in table
+        {% else %}
+            RESPOND TYPE=error  MSG="{table_name|capitalize} '{name}' is unknown!"
+            RESPOND TYPE=error  MSG="Use SET_{table_name|upper} macro to add this new {table_name}!"
+            _RAISE_ERROR MSG="{"Unable to load %s from %s" % (name,table_name)) }"
+
+        {% endif %}
+    {% endif %}

--- a/macros/miscs/prompt.cfg
+++ b/macros/miscs/prompt.cfg
@@ -1,7 +1,9 @@
-### GUI functions
+### prompt GUI functions
 # Mainsail introduces a new way to interact with the user, using the RESPOND command.
 # This snippet provides a set of macros to create prompts and messages boxes in the GUI.
 # it also works with Fluidd and Klipperscreen.
+# Prompt GUI generate a lot of console outputs, those can be filtered in Fluidd (not in Mainsail)
+# parameters > console > add filter > start with > // action:prompt_
 
 # confirmation prompt
 [gcode_macro _PROMPT_QUESTION]
@@ -21,14 +23,21 @@ gcode:
     RESPOND TYPE=command MSG="action:prompt_show"
 
 # selection prompt
-# Usage: _PROMPT_SELECT TITLE=<TITLE> MSG=<MSG> OPTIONS=<comma separated values> 
+# Usage: _PROMPT_SELECT TITLE=<TITLE> MSG=<MSG> OPTIONS=<comma separated values>
+#           [VALUES=<comma separated values>] [COLORS=<comma separated values>]
 #           ACTION=<MACRO> KEY=<PARAM TO ADD TO ACTION MACRO WITH OPTION VALUE>
 [gcode_macro _PROMPT_SELECT]
 gcode:
+    {% set available_colors=['primary', 'secondary', 'info', 'warning', 'error']%}
+    {% set options = params.OPTIONS.split(",") %}
+    {% set values = (params.VALUES|default(params.OPTIONS)).split(",") %}
+    {% set colors = (params.COLORS|default("")).split(",") %}
+
     RESPOND TYPE=command MSG="action:prompt_begin {params.TITLE|default("Klippain-Chocolate")}"
     RESPOND TYPE=command MSG="action:prompt_text {params.MSG}"
-    {% for option in params.OPTIONS.split(",") %}
-        RESPOND TYPE=command MSG="action:prompt_button {option}|{params.ACTION} {params.KEY}=\"{option}\""
+    {% for i in range(options|length) %}
+        {% set color = "|%s" % colors[i] if colors[i] in available_colors else "" %}
+        RESPOND TYPE=command MSG="action:prompt_button {options[i]}|{params.ACTION} {params.KEY}=\"{values[i]}\"{color}"
     {% endfor %}
     RESPOND TYPE=command MSG="action:prompt_footer_button ABORT|_PROMPT_CLOSE|error"
     RESPOND TYPE=command MSG="action:prompt_show"

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -46,8 +46,8 @@ gcode:
 
     ## init material settings
     _MIGRATE_MATERIAL_SETTINGS
-    _LOAD_PROFILE_BY_NAME NAME=material
-    _LOAD_PROFILE_BY_NAME NAME=buildplate
+    _LOAD_PROFILE_BY_NAME TABLE=material
+    _LOAD_PROFILE_BY_NAME TABLE=buildplate
 
     # build the start print sequence
     _INIT_START_PRINT_ACTIONS

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -46,8 +46,8 @@ gcode:
 
     ## init material settings
     _MIGRATE_MATERIAL_SETTINGS
-    _LOAD_MATERIAL_PROFILES
-    _RESTORE_LAST_USED_MATERIAL
+    _LOAD_PROFILE_BY_NAME NAME=material
+    _LOAD_PROFILE_BY_NAME NAME=buildplate
 
     # build the start print sequence
     _INIT_START_PRINT_ACTIONS

--- a/user_templates/save_variables.cfg
+++ b/user_templates/save_variables.cfg
@@ -1,2 +1,5 @@
 [Variables]
 mmu_calibration_0 = 1.0
+material_table = = {'PLA': {'pressure_advance': 0.0525, 'retract_length': 0.75, 'filter_speed': 0}, 'PET': {'pressure_advance': 0.065, 'retract_length': 1.4, 'retract_speed': 30, 'unretract_speed': 20, 'filter_speed': 0, 'additional_z_offset': 0.02}, 'ABS': {}, 'TPU': {'pressure_advance': 0.05, 'retract_length': 0.2, 'retract_speed': 5, 'unretract_speed': 5, 'filter_speed': 0, 'additional_z_offset': 0.04, 'filament_sensor': 0}}
+
+


### PR DESCRIPTION
The current PR adds buildplate db support with prompt as _MATERIAL. It shares macros with _MATERIAL.
Previous _LOAD_MATERIAL macros becomes _LOAD_PROFILE_BY_NAME TABLE=material, ...

_MATERIAL do not copy material table in material_parameters anymore. START_PRINT had to be split to ensure START_PRINT calls the array before material settings is called

Thanks