### PR TITLE
fix typo in save_variables.cfg

### DIFF
--- a/user_templates/save_variables.cfg
+++ b/user_templates/save_variables.cfg
@@ -1,5 +1,5 @@
 [Variables]
 mmu_calibration_0 = 1.0
-material_table = = {'PLA': {'pressure_advance': 0.0525, 'retract_length': 0.75, 'filter_speed': 0}, 'PET': {'pressure_advance': 0.065, 'retract_length': 1.4, 'retract_speed': 30, 'unretract_speed': 20, 'filter_speed': 0, 'additional_z_offset': 0.02}, 'ABS': {}, 'TPU': {'pressure_advance': 0.05, 'retract_length': 0.2, 'retract_speed': 5, 'unretract_speed': 5, 'filter_speed': 0, 'additional_z_offset': 0.04, 'filament_sensor': 0}}
+material_table = {'PLA': {'pressure_advance': 0.0525, 'retract_length': 0.75, 'filter_speed': 0}, 'PET': {'pressure_advance': 0.065, 'retract_length': 1.4, 'retract_speed': 30, 'unretract_speed': 20, 'filter_speed': 0, 'additional_z_offset': 0.02}, 'ABS': {}, 'TPU': {'pressure_advance': 0.05, 'retract_length': 0.2, 'retract_speed': 5, 'unretract_speed': 5, 'filter_speed': 0, 'additional_z_offset': 0.04, 'filament_sensor': 0}}
 
 


### PR DESCRIPTION
After new install Klipper fails to start due to a typo in save_variables.cfg 
Sorry about that.

