### PR TITLE
fix install/uninstall scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ Finally, Klippain requires a few simple steps to configure and customize it for 
   >
   > General rule to keep the auto-update feature working: **never modify Klippain files directly**, but instead add overrides as per [the documentation](./docs/overrides.md)! To proceed, you can modify all the pre-installed templates in your config root folder (`printer.cfg`, `mcu.cfg`, `variables.cfg` and `overrides.cfg`) as they will be preserved on update.
 
+### Installation Options
+
+The install script supports several command line options:
+
+```bash
+cd ~/klippain_config
+bash ./install.sh [-b <branch_name>] [--reinstall-templates] [--reinstall-addons]
+```
+
+Available options:
+- `-b` or `--branch`: Select Klippain branch to install
+  - `main`: Default stable branch
+  - `beta`: Advanced features branch
+  - `develop`: Latest development branch
+- `--reinstall-templates`: Regenerate MCU templates in `mcus.cfg` (previous file backed up)
+- `--reinstall-addons`: Prompt to install optional components like Shaketune
+
 
 ## Removing Klippain
 

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,10 @@
 ###### AUTOMATED INSTALL AND UPDATE SCRIPT ######
 #################################################
 # Written by yomgui1 & Frix_x
-# @version: 1.3
+# @version: 1.5
 
 # CHANGELOG:
+#   v1.5: - add options : to choose a custom git branch during install, to reinstall MCU templates 
 #   v1.4: added Shake&Tune install call
 #   v1.3: - added a warning on first install to be sure the user wants to install klippain and fixed a bug
 #           where some artefacts of the old user config where still present after the install (harmless bug but not clean)
@@ -26,8 +27,11 @@ FRIX_CONFIG_PATH="${HOME}/klippain_config"
 BACKUP_PATH="${HOME}/klippain_config_backups"
 # Where the Klipper folder is located (ie. the internal Klipper firmware machinery)
 KLIPPER_PATH="${HOME}/klipper"
-# Branch from Frix-x/klippain repo to use during install (default: main)
-FRIX_BRANCH="main"
+# Git URL of the Frix-x/klippain repo to use during install (default: official repo)
+FRIX_CONFIG_GIT_URL="https://github.com/elpopo-eng/klippain-chocolate.git"
+
+# for update purpose
+NEW_INSTALL=false
 
 
 set -eu
@@ -48,20 +52,13 @@ function preflight_checks {
         exit -1
     fi
 
-    local install_klippain_answer
     if [ ! -f "${USER_CONFIG_PATH}/.VERSION" ]; then
         echo "[PRE-CHECK] New installation of Klippain detected!"
         echo "[PRE-CHECK] This install script will WIPE AND REPLACE your current Klipper config with the full Klippain system (a backup will be kept)"
         echo "[PRE-CHECK] Be sure that the printer is idle before continuing!"
         
-        read < /dev/tty -rp "[PRE-CHECK] Are you sure want to proceed and install Klippain? (y/N) " install_klippain_answer
-        if [[ -z "$install_klippain_answer" ]]; then
-            install_klippain_answer="n"
-        fi
-        install_klippain_answer="${install_klippain_answer,,}"
-
-        if [[ "$install_klippain_answer" =~ ^(yes|y)$ ]]; then
-            printf "[PRE-CHECK] Installation confirmed! Continuing...\n\n"
+        if prompt "[PRE-CHECK] Are you sure want to proceed and install Klippain? (y/N) " n ; then
+            echo -e "[PRE-CHECK] Installation confirmed! Continuing...\n"
         else
             echo "[PRE-CHECK] Installation was canceled!"
             exit -1
@@ -72,21 +69,66 @@ function preflight_checks {
 
 # Step 2: Check if the git config folder exist (or download it)
 function check_download {
-    local frixtemppath frixreponame
+    local frixtemppath frixreponame frixbranchname frixrepourl currentbranch nextbranch
     frixtemppath="$(dirname ${FRIX_CONFIG_PATH})"
     frixreponame="$(basename ${FRIX_CONFIG_PATH})"
-    frixbranchname="${FRIX_BRANCH}"
+    frixbranchname="${FRIX_BRANCH:-main}"
+    frixrepourl="${FRIX_CONFIG_GIT_URL}"
+
 
     if [ ! -d "${FRIX_CONFIG_PATH}" ]; then
+        NEW_INSTALL=true
         echo "[DOWNLOAD] Downloading Klippain repository..."
-        if git -C $frixtemppath clone -b $frixbranchname https://github.com/elpopo-eng/klippain-chocolate.git $frixreponame; then
+        if git -C $frixtemppath clone -b $frixbranchname  $frixrepourl $frixreponame; then
             printf "[DOWNLOAD] Download complete!\n\n"
         else
             echo "[ERROR] Download of Klippain git repository failed!"
             exit -1
         fi
     else
-        printf "[DOWNLOAD] Klippain repository already found locally. Continuing...\n\n"
+        # retrieve current branch
+        currentbranch=$(git -C ${FRIX_CONFIG_PATH} rev-parse --abbrev-ref HEAD)
+        # check if the user asked for a branch change
+        nextbranch="${FRIX_BRANCH:-$currentbranch}"
+
+        echo -e "[DOWNLOAD] Klippain repository already found locally.\n" \
+            "  Repo : $frixrepourl branch : $currentbranch\nContinuing...\n"
+        
+        # if the branch requested is different than the current one, ask the user if he wants to switch
+        if [[ "${nextbranch}" != "${currentbranch}" ]]; then
+            if prompt "[UPDATE] Current branch is '$currentbranch', do you want to switch to branch '$nextbranch'? (Y/n) " y; then
+                echo "[UPDATE] Switching branch..."
+                git -C ${FRIX_CONFIG_PATH} switch $nextbranch
+                echo "[UPDATE] Change branch '$currentbranch' -> '$nextbranch' done!"
+                currentbranch=$nextbranch
+            else
+                echo -e "[UPDATE] Branch switch canceled by user. Continuing with current branch '$currentbranch'...\n"
+                nextbranch=$currentbranch
+            fi
+        fi
+
+        # update: required if script run in ssh instead of moonraker
+        if [[ "${currentbranch}" == "${nextbranch}" ]]; then
+            echo "[UPDATE] Checking for updates to Klippain repository..."
+
+            git -C ${FRIX_CONFIG_PATH} fetch origin $nextbranch
+            LOCAL=$(git -C ${FRIX_CONFIG_PATH} rev-parse @)
+            REMOTE=$(git -C ${FRIX_CONFIG_PATH} rev-parse @{u})
+
+            if [ $LOCAL = $REMOTE ]; then
+                echo -e "[UPDATE] Klippain repository is already up to date!\n"
+            else
+                echo "[UPDATE] Updates found! Downloading latest changes..."
+                if git -C ${FRIX_CONFIG_PATH} pull --ff-only origin $nextbranch; then
+                    echo -e "[UPDATE] Klippain repository updated successfully!\n"
+                else
+                    echo "[ERROR] Failed to update Klippain repository! Please resolve any conflicts manually."
+                    exit -1
+                fi
+            fi
+        else
+            echo -e "[UPDATE] Skipping update check. Continuing...\n"
+        fi
     fi
 }
 
@@ -121,7 +163,7 @@ function install_config {
     mkdir -p ${USER_CONFIG_PATH}
 
     # Symlink Frix-x config folders (read-only git repository) to the user's config directory
-    for dir in config macros scripts moonraker; do
+    for dir in config macros scripts moonraker addons; do
         ln -fsn ${FRIX_CONFIG_PATH}/$dir ${USER_CONFIG_PATH}/$dir
     done
 
@@ -132,34 +174,39 @@ function install_config {
         printf "[INSTALL] New installation detected: config templates will be set in place!\n\n"
         find ${FRIX_CONFIG_PATH}/user_templates/ -type d -name 'mcu_defaults' -prune -o -type f -print | xargs cp -ft ${USER_CONFIG_PATH}/
         install_mcu_templates
+    # Reinstall templates if the user asked for it
+    elif $REINSTALL_TEMPLATES; then
+        echo "[INSTALL] Reinstalling config templates as requested by user!"
+        echo -e "[INSTALL] ${RED}WARNING: this will OVERWRITE your current mcu.cfg file!${DEFAULT}"
+        prompt "[INSTALL] Are you sure you want to reinstall the config templates? (y/N)" n &&
+        cat /dev/null > ${USER_CONFIG_PATH}/mcu.cfg &&
+        install_mcu_templates
+    else
+        printf "[INSTALL] Existing installation detected: skipping config templates installation!\n\n"
     fi
 
     # CHMOD the scripts to be sure they are all executables (Git should keep the modes on files but it's to be sure)
-    chmod +x ${FRIX_CONFIG_PATH}/install.sh
-    chmod +x ${FRIX_CONFIG_PATH}/uninstall.sh
-    chmod +x ${FRIX_CONFIG_PATH}/scripts/system_info.py
-    chmod +x ${FRIX_CONFIG_PATH}/scripts/service_restart.py
+    chmod +x ${FRIX_CONFIG_PATH}/*.sh
+    chmod +x ${FRIX_CONFIG_PATH}/scripts/*.py
     
-    # Symlink the gcode_shell_command.py file in the correct Klipper folder (erased to always get the last version)
-    ln -fsn ${FRIX_CONFIG_PATH}/scripts/gcode_shell_command.py ${KLIPPER_PATH}/klippy/extras
+    # Symlink the gcode_shell_command.py file in the correct Klipper folder (erased to always get the last version) not Kalico
+    if [ ! -f "${KLIPPER_PATH}/klippy/extras/gcode_shell_command.py" ] || [ -L "${KLIPPER_PATH}/klippy/extras/gcode_shell_command.py" ]; then
+        ln -fsn ${FRIX_CONFIG_PATH}/scripts/gcode_shell_command.py ${KLIPPER_PATH}/klippy/extras
+    else
+        echo "[INSTALL] gcode_shell_command.py plugin already installed, skipping..."
+    fi
+    
 
     # Create or update the config version tracking file in the user config directory
     git -C ${FRIX_CONFIG_PATH} rev-parse HEAD > ${USER_CONFIG_PATH}/.VERSION
 }
 
-
 # Helper function to ask and install the MCU templates if needed
 function install_mcu_templates {
-    local install_template file_list main_template install_toolhead_template toolhead_template install_mmu_template
-
-    read < /dev/tty -rp "[CONFIG] Would you like to select and install MCU wiring templates files? (Y/n) " install_template
-    if [[ -z "$install_template" ]]; then
-        install_template="y"
-    fi
-    install_template="${install_template,,}"
+    local  file_list main_template  toolhead_template
 
     # Check and exit if the user do not wants to install an MCU template file
-    if [[ "$install_template" =~ ^(no|n)$ ]]; then
+    if ! prompt "[CONFIG] Would you like to select and install MCU wiring templates files? (Y/n) " y; then
         printf "[CONFIG] Skipping installation of MCU templates. You will need to manually populate your own mcu.cfg file!\n\n"
         return
     fi
@@ -169,6 +216,7 @@ function install_mcu_templates {
     while IFS= read -r -d '' file; do
         file_list+=("$file")
     done < <(find "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/main" -maxdepth 1 -type f -print0)
+    file_list=($(printf '%s\n' "${file_list[@]}" | sort))
     echo "[CONFIG] Please select your main MCU in the following list:"
     for i in "${!file_list[@]}"; do
         echo "  $((i+1))) $(basename "${file_list[i]}")"
@@ -185,18 +233,13 @@ function install_mcu_templates {
     fi
 
     # Next see if the user use a toolhead board
-    read < /dev/tty -rp "[CONFIG] Do you have a toolhead MCU and want to install a template? (y/N) " install_toolhead_template
-    if [[ -z "$install_toolhead_template" ]]; then
-        install_toolhead_template="n"
-    fi
-    install_toolhead_template="${install_toolhead_template,,}"
-
     # Check if the user wants to install a toolhead MCU template
-    if [[ "$install_toolhead_template" =~ ^(yes|y)$ ]]; then
+    if prompt "[CONFIG] Do you have a toolhead MCU and want to install a template? (y/N) " n; then
         file_list=()
         while IFS= read -r -d '' file; do
             file_list+=("$file")
         done < <(find "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/toolhead" -maxdepth 1 -type f -print0)
+        file_list=($(printf '%s\n' "${file_list[@]}" | sort))
         echo "[CONFIG] Please select your toolhead MCU in the following list:"
         for i in "${!file_list[@]}"; do
             echo "  $((i+1))) $(basename "${file_list[i]}")"
@@ -214,18 +257,13 @@ function install_mcu_templates {
     fi
 
     # Next see if the user use an MMU/ERCF board
-    read < /dev/tty -rp "[CONFIG] Do you have an MMU/ERCF MCU and want to install a template? (y/N) " install_mmu_template
-    if [[ -z "$install_mmu_template" ]]; then
-        install_mmu_template="n"
-    fi
-    install_mmu_template="${install_mmu_template,,}"
-
     # Check if the user wants to install an MMU/ERCF MCU template
-    if [[ "$install_mmu_template" =~ ^(yes|y)$ ]]; then
+    if prompt "[CONFIG] Do you have an MMU/ERCF MCU and want to install a template? (y/N) " n; then
         file_list=()
         while IFS= read -r -d '' file; do
             file_list+=("$file")
         done < <(find "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/mmu" -maxdepth 1 -type f -print0)
+        file_list=($(printf '%s\n' "${file_list[@]}" | sort))
         echo "[CONFIG] Please select your MMU/ERCF MCU in the following list:"
         for i in "${!file_list[@]}"; do
             echo "  $((i+1))) $(basename "${file_list[i]}")"
@@ -244,18 +282,13 @@ function install_mcu_templates {
     fi
 
    # Finally see if the user use an expander board
-    read < /dev/tty -rp "[CONFIG] Do you have an expander board and want to install a template? (y/N) " install_expander_template
-    if [[ -z "$install_expander_template" ]]; then
-        install_expander_template="n"
-    fi
-    install_expander_template="${install_expander_template,,}"
-
     # Check if the user wants to install an expander MCU template
-    if [[ "$install_expander_template" =~ ^(yes|y)$ ]]; then
+    if prompt "[CONFIG] Do you have an expander board and want to install a template? (y/N) " n; then
         file_list=()
         while IFS= read -r -d '' file; do
             file_list+=("$file")
         done < <(find "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/expand" -maxdepth 1 -type f -print0)
+        file_list=($(printf '%s\n' "${file_list[@]}" | sort))
         echo "[CONFIG] Please select your expander MCU in the following list:"
         for i in "${!file_list[@]}"; do
             echo "  $((i+1))) $(basename "${file_list[i]}")"
@@ -273,13 +306,78 @@ function install_mcu_templates {
     fi
 }
 
+# Installation of addons if any
+function install_addons {
+    if $NEW_INSTALL || $REINSTALL_ADDONS; then
+        echo "[ADDONS-INSTALL] New installation detected, installing addons..."
+        if prompt "[ADDONS-INSTALL] Do you want to install/update klippain-shaketune addon now? (Y/n) " y; then
+            wget -O - https://raw.githubusercontent.com/Frix-x/klippain-shaketune/main/install.sh | bash
+            # Shake&Tune installation code goes here
+        else
+            echo "[ADDONS-INSTALL] Skipping klippain-shaketune addon installation as per user request."
+        fi
+
+        # Future addons installation can be added here
+
+    else
+        if [ -d "${HOME}/klippain_shaketune" ]; then
+            echo "[ADDONS-INSTALL] klippain-shaketune addon detected, updating..."
+            wget -O - https://raw.githubusercontent.com/Frix-x/klippain-shaketune/main/install.sh | bash
+        fi
+
+
+    fi
+}
+
 # Step 5: restarting Klipper
 function restart_klipper {
     echo "[POST-INSTALL] Restarting Klipper..."
     sudo systemctl restart klipper
 }
 
+## utility functions and main script body below ##
 
+# Colors helpers
+RED=$'\033[1;31m'
+MAGENTA=$'\033[0;35m'
+DEFAULT=$'\033[0m'
+
+prompt() {
+  local default="Yn"
+  [ $# -eq 2 ] && [ ${2^} = "N" ] && default="yN"
+ 
+  while true; do
+    read -p "${MAGENTA}$1${DEFAULT}" yn
+    case $yn in
+    [Yy]*) return 0 ;;
+    "")
+      [ $default = "yN" ] && return 1 # Return 1 if N, 0 if Y is default
+      return 0 # Return 0 on Enter key press (Y as default)
+      ;; 
+    [Nn]*) return 1 ;;
+    esac
+    line_count=$(echo $1 | wc -l)
+    for ((i=0; i<$line_count; i++)); do
+      echo -ne '\e[1A\e[K' # Move cursor up and clear line
+    done
+  done
+}
+
+parse_args() {
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      -b|--branch) FRIX_BRANCH="$2"; shift ;;
+      --reinstall-templates) REINSTALL_TEMPLATES=true ;;
+      --reinstall-addons) REINSTALL_ADDONS=true ;;
+      --) shift; break ;;
+      -?*) echo "Unknown option: $1" ;;
+    esac
+    shift
+  done
+}
+REINSTALL_TEMPLATES=false
+REINSTALL_ADDONS=false
+NEW_INSTALL=false
 BACKUP_DIR="${BACKUP_PATH}/$(date +'%Y_%m_%d-%H%M%S')"
 
 printf "\n======================================\n"
@@ -287,13 +385,13 @@ echo "- Klippain install and update script -"
 printf "======================================\n\n"
 
 # Run steps
+parse_args "$@"
 preflight_checks
 check_download
 backup_config
 install_config
+install_addons
 restart_klipper
-
-wget -O - https://raw.githubusercontent.com/Frix-x/klippain-shaketune/main/install.sh | bash
 
 echo "[POST-INSTALL] Everything is ok, Klippain installed and up to date!"
 echo "[POST-INSTALL] Be sure to check the breaking changes on the release page: https://github.com/elpopo-eng/klippain-chocolate/releases"


### PR DESCRIPTION
## Install script
The current PR adds options to install script : 
`-b <branch>` to select another branch (default is `main`)
`--resintall-templates`  to rewrite `mcus.cfg`
`--resinstall-addons` to run addons install on update

A prompt helper fix prompts and reinforces security : only `y/x/enter` are allowed answers. It also adds color.

Shaketune is now considered as addon, installation will be optional 

## Uninstall script
The PR fix prompt, ( user was prompted only when  .VERSION file was not found !? and uninstall run )
Config folder will be delete/restore only if .VERSION file is found, to avoid deletion of  a non-klippain config.

