### PR TITLE
fix no_probe (voron v0) homing

### DIFF
--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -24,9 +24,11 @@ gcode:
     {% set y_position_endstop = printer["configfile"].config["stepper_y"]["position_endstop"]|float %}
     {% set x_position_center = ( printer.toolhead.axis_maximum.x|float + printer.toolhead.axis_minimum.x|float ) /2 %}
     {% set y_position_center = ( printer.toolhead.axis_maximum.y|float + printer.toolhead.axis_minimum.y|float ) /2 %}
-    
-    {% set x_probe_offset = printer.configfile.settings[printer.probe.name].x_offset %}
-    {% set y_probe_offset = printer.configfile.settings[printer.probe.name].y_offset %}
+ 
+    {% if probe_type_enabled != 'none' %}   
+        {% set x_probe_offset = printer.configfile.settings[printer.probe.name].x_offset %}
+        {% set y_probe_offset = printer.configfile.settings[printer.probe.name].y_offset %}
+    {% endif %}
 
 
 


### PR DESCRIPTION
Hello,

When using no_probe.cfg (like on a stock voron v0.2), printer.probe and printer.probe.name are not defined in macros/base/homing/homing_override.cfg

This is a quick fix, testing if probe_type_enabled != 'none' before using printer.probe.