### PR TITLE
Prime_line , fix raise_error conditions

### DIFF
--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -49,8 +49,8 @@ gcode:
                                 else prime_line_x %}
         {% set prime_line_y = 2*center_y - prime_line_y if prime_line_direction == "Y" and ((prime_line_y > center_y and yMaxSpec < center_y) or (prime_line_y < center_y and yMinSpec > center_y))
                                 else prime_line_y %}
-        {% if (prime_line_x > xMinSpec - prime_line_margin and prime_line_x < xMaxSpec + prime_line_margin) or
-              (prime_line_y > yMinSpec - prime_line_margin and prime_line_y < yMaxSpec + prime_line_margin) %}
+        {% if (prime_line_x > xMinSpec - prime_line_margin and prime_line_x < xMaxSpec + prime_line_margin and prime_line_direction == "Y") or
+              (prime_line_y > yMinSpec - prime_line_margin and prime_line_y < yMaxSpec + prime_line_margin and prime_line_direction == "X") %}
                 _RAISE_ERROR MSG="Adaptive_primeline is in exclude object area, unable to Start print, change primeline position or disable adaptive_primeline"
         {% endif %}
         {% set prime_line_x = [[prime_line_x, xMinSpec - prime_line_margin]|max, xMaxSpec + prime_line_margin]|min %}


### PR DESCRIPTION
Hi @elpopo-eng 
The PR fixes the behavior whereby the test may generate an error even if the primeline is not within the “size/exclude_object” area (e.g., wide in width but narrow in depth).
Thanks.