### PR TITLE
Fix Cartographer plugin

### DIFF
--- a/config/hardware/probes/eddy_tap_probe.cfg
+++ b/config/hardware/probes/eddy_tap_probe.cfg
@@ -26,15 +26,15 @@ gcode:
         {% set touch_location_x, touch_location_y = printer.configfile.config.scanner.scanner_touch_location.split(',')|map('trim')|map('float') %}
     {% endif %}
 
-     {% if printer.configfile.settings.beacon is defined or printer.configfile.settings.cartographer is defined %}
-            # If there is a bed_mesh enabled and a zero_reference_position set, we retrieve it to home on it
-            # Else, we default to the center of the bed
-            {% if not bed_mesh_enabled or not printer["configfile"].config["bed_mesh"]["zero_reference_position"] %}
-                {% set touch_location_x = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
-                {% set touch_location_y = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
-            {% else %}
-                {% set touch_location_x, touch_location_y = printer["configfile"].config["bed_mesh"]["zero_reference_position"].split(',')|map('trim')|map('float') %}
-            {% endif %}
+    {% if printer.configfile.settings.beacon is defined or printer.configfile.settings.cartographer is defined %}
+        # If there is a bed_mesh enabled and a zero_reference_position set, we retrieve it to home on it
+        # Else, we default to the center of the bed
+        {% if not bed_mesh_enabled or not printer["configfile"].config["bed_mesh"]["zero_reference_position"] %}
+            {% set touch_location_x = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
+            {% set touch_location_y = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
+        {% else %}
+            {% set touch_location_x, touch_location_y = printer["configfile"].config["bed_mesh"]["zero_reference_position"].split(',')|map('trim')|map('float') %}
+        {% endif %}
     {% endif %}
    
     # randomise a little bit tap location

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -308,7 +308,9 @@ gcode:
             # If it's the voron tap, we put it to a safe temperature
             {% if probe_type_enabled == "dockable_virtual" or probe_type_enabled == "tap_probe" %}
                 # with Cartographer and beacon we don't touch the bed so no need to activate_probe
-                {% if printer.configfile.settings.scanner is not defined and printer.configfile.settings.beacon is not defined %}
+                {% if printer.configfile.settings.scanner is not defined 
+                    and printer.configfile.settings.beacon is not defined 
+                    and printer.configfile.settings.cartographer is not defined %}
                     ACTIVATE_PROBE
                 {% endif %}
             {% endif %}
@@ -341,7 +343,9 @@ gcode:
         # if dockable probe as virtual endstop, then dock the probe
         {% if probe_type_enabled == "dockable_virtual" or probe_type_enabled == "tap_probe" %}
             # with Cartographer we don't touch the bed so no need to activate_probe
-            {% if printer.configfile.settings.scanner is not defined and printer.configfile.settings.beacon is not defined %}
+            {% if printer.configfile.settings.scanner is not defined 
+                and printer.configfile.settings.beacon is not defined 
+                and printer.configfile.settings.cartographer is not defined %}
                 DEACTIVATE_PROBE
             {% endif %}
         {% endif %}        

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -240,7 +240,10 @@ gcode:
            # if probe is a tap_probe
             
             # Clean
-            {% if _u_vars.purge_and_brush_enabled and printer.configfile.settings.scanner is not defined and printer.configfile.settings.beacon is not defined %}
+            {% if _u_vars.purge_and_brush_enabled 
+                and printer.configfile.settings.scanner is not defined 
+                and printer.configfile.settings.cartographer is not defined
+                and printer.configfile.settings.beacon is not defined %}
                 {% set _= start_actions_list.append( {'module' : 'CLEAN'})%}
             {% endif %}
 
@@ -255,7 +258,10 @@ gcode:
             {% endif %}
 			
 			# Clean before tap with cartographer survey or beacon contact
-			{% if _u_vars.purge_and_brush_enabled and (printer.configfile.settings.scanner is defined or printer.configfile.settings.beacon is defined)  %}
+			{% if _u_vars.purge_and_brush_enabled 
+                and (printer.configfile.settings.scanner is defined 
+                    or printer.configfile.settings.cartographer is defined
+                    or printer.configfile.settings.beacon is defined) %}
 				{% set _= start_actions_list.append( {'module' : 'CLEAN'})%}
 			{% endif %}
 			


### PR DESCRIPTION
This pull request modifies several macro configuration files to improve compatibility with the Cartographer plugin. The main changes ensure that probe activation, deactivation, and cleaning actions account for the presence of the Cartographer plugin, alongside Cartographer survey and beacon systems.

Probe activation/deactivation logic fix:
* Updated probe activation/deactivation in `homing_override.cfg` to check for Cartographer plugin presence


Cleaning logic fix:
* cleaning just before home with touch