### PR TITLE
Fix install.sh prompt when called from pipe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -380,7 +380,7 @@ prompt() {
   [ $# -eq 2 ] && [ ${2^} = "N" ] && default="yN"
  
   while true; do
-    read -p "${MAGENTA}$1${DEFAULT}" yn
+    read -p "${MAGENTA}$1${DEFAULT}" yn < /dev/tty
     case $yn in
     [Yy]*) return 0 ;;
     "")


### PR DESCRIPTION
Hello

Discussion : https://discord.com/channels/811518442721116232/1093260642556846111/1474444102706663465
## Symptoms :
The install.sh works locally but exit on error when called from pipe.

## Root cause :
The prompt does not precise console as entry for interactive features.

Thanks to @Benoitone for reporting this.