### PR TITLE
ADAPTIVE_BESH_MESH uses Klipper adaptive

### DIFF
--- a/docs/features/adaptive_bed_mesh.md
+++ b/docs/features/adaptive_bed_mesh.md
@@ -56,11 +56,6 @@ If you want to install it to your own custom config, here is the way to go:
 
   4. **VERY IMPORTANT CHECKS**:
      - Check that the `BED_MESH_CALIBRATE` command is working correctly now or fix your `[bed_mesh]` section.
-     - Check that the `mesh_min`, `mesh_max`, `probe_count` and `mesh_pps` config entries in your `[bed_mesh]` section are specified using **TWO numbers** as my macro is waiting for it and will fail if there is only one specified. Something like this is ok:
-
-       ```
-       probe_count: 9,9
-       ```
 
   5. My macro is using the `RESPOND` command of Klipper for debugging purposes. So, you need to: either be sure there is a `[respond]` section in your config (or add it). Or, if you don't want to see the messages, delete all the `RESPOND msg=...` lines.
 
@@ -90,11 +85,11 @@ In your klipper config, modify your `PRINT_START` macro definition by adding two
 </details>
 
 
-Regarding the parameters availables, you can use them either when calling the `ADAPTIVE_BED_MESH` macro or the `COMPUTE_MESH_PARAMETERS` macro. Please see this table for details:
+Regarding the parameters availables, you can use them when calling the `ADAPTIVE_BED_MESH` macro. Please see this table for details:
 
 | parameters | default value | description |
 |-----------:|---------------|-------------|
-|SIZE||"xMin_yMin_xMax_yMax" of the zone you want to do the mesh. Usually this is coming automatically from the slicer but this can still be used mannually when you want to call the adaptive mesh macro by hand (not during a print)|
+|SIZE||"xMin_yMin_xMax_yMax" of the zone you want to do the mesh. Usually this is coming automatically from the slicer but this can still be used manually when you want to call the adaptive mesh macro by hand (not during a print)|
 |MARGIN|5|margin in mm to add around the first layer for the probing area|
 |FORCE_MESH|0|force a 3×3 mesh even for very small parts (when less than 3×3 points are computed)|
 

--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -41,7 +41,7 @@ gcode:
     M400
 
     CLEAR_PAUSE
-
+    _SET_FL_SIZE RESET=1
     {% if bed_mesh_enabled %}
         BED_MESH_CLEAR
     {% endif %}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -10,7 +10,7 @@ variable_initial_tool: 0
 variable_referenced_tools: "!referenced_tools!"
 variable_sync_mmu_extruder: 0
 variable_material: "XXX"
-variable_fl_size: "0_0_0_0"
+variable_fl_size: [0,0,0,0]
 variable_bed_mesh_profile: ""
 variable_total_layer: 0
 variable_adaptive_primeline: 1
@@ -23,7 +23,7 @@ gcode:
     {% set CHAMBER_TEMP = params.CHAMBER|default(printer["gcode_macro _USER_VARIABLES"].print_default_chamber_temp)|int %} # Chamber temperature setpoint
     {% set CHAMBER_MAXTIME = params.CHAMBER_MAXTIME|default(printer["gcode_macro _USER_VARIABLES"].print_default_chamber_max_heating_time)|int %} # Chamber heatsoak timeout in minutes
     {% set MATERIAL = params.MATERIAL|default(printer.save_variables.variables.current_material_name)|default(printer["gcode_macro _USER_VARIABLES"].print_default_material)|string %} # Material type set in the slicer
-    {% set FL_SIZE = params.SIZE|default("0_0_0_0")|string %} # Get bounding box of the first layer for the adaptive bed mesh
+    {% set SIZE = params.SIZE|default("0_0_0_0")|string %} # Get bounding box of the first layer for the adaptive bed mesh
     {% set BED_MESH_PROFILE = params.MESH|default("")|string %} # Bed mesh profile to load
     {% set ADAPTIVE_PRIMELINE = params.ADAPTIVE_PRIMELINE|default(1)|int %} # Weither to do or not an adaptive prime line near the real print zone
 
@@ -51,7 +51,7 @@ gcode:
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=chamber_temp VALUE={CHAMBER_TEMP}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=chamber_maxtime VALUE={CHAMBER_MAXTIME}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=material VALUE='"{MATERIAL}"'
-    SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=fl_size VALUE='"{FL_SIZE}"'
+    _SET_FL_SIZE SIZE={SIZE}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=bed_mesh_profile VALUE='"{BED_MESH_PROFILE}"'
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=adaptive_primeline VALUE={ADAPTIVE_PRIMELINE}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=initial_tool VALUE={INITIAL_TOOL}
@@ -185,19 +185,42 @@ gcode:
     {% endif %}
 
     G92 E0.0
+    _SET_FL_SIZE RESET=1
+
+
+[gcode_macro _SET_FL_SIZE]
+description: Compute mesh area, store it for later use (adaptive_bed_mesh, primeline) 
+gcode:
+    {% set fl_size = (params.SIZE|default("0_0_0_0")).split('_')|map('float')|list %}
+    {% set reset = params.RESET|default(0)|int == 1 %}
+    
+    {% if reset %}
+        {% set fl_size = [0,0,0,0] %}
+    {% elif printer.exclude_object.objects != [] and fl_size == [0,0,0,0] %}
+         # If SIZE is not defined, we fallback to use the [exclude_object] tags
+         # This method is derived from Kyleisah KAMP repository: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging)
+         RESPOND MSG="No SIZE parameter, using the [exclude_object] tags as print area"
+        {% set eo_points = printer.exclude_object.objects|map(attribute='polygon')|sum(start=[]) %}
+        {% set fl_size = [
+                eo_points|map(attribute=0)|min,
+                eo_points|map(attribute=1)|min,
+                eo_points|map(attribute=0)|max,
+                eo_points|map(attribute=1)|max
+                ] %}
+    {% endif %}
+    SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=fl_size VALUE="{fl_size}"
 
 
 [gcode_macro _MODULE_PRIMELINE]
 gcode:
     # ----- PRIME LINE -------------------------------------------
-    {% set FL_SIZE = printer["gcode_macro START_PRINT"].fl_size %}
     {% set ADAPTIVE_PRIMELINE = printer["gcode_macro START_PRINT"].adaptive_primeline %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if verbose %}
         RESPOND MSG="Executing a primeline..."
     {% endif %}
-    PRIMELINE SIZE={FL_SIZE} ADAPTIVE_MODE={ADAPTIVE_PRIMELINE}
+    PRIMELINE ADAPTIVE_MODE={ADAPTIVE_PRIMELINE}
 
 
 [gcode_macro _MODULE_HEATSOAK_BED]
@@ -386,7 +409,6 @@ gcode:
 [gcode_macro _MODULE_BED_MESH]
 gcode:
     # ----- BED MESH -------------------------------------------
-    {% set FL_SIZE = printer["gcode_macro START_PRINT"].fl_size %}
     {% set BED_MESH_PROFILE = printer["gcode_macro START_PRINT"].bed_mesh_profile %}
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
@@ -398,7 +420,7 @@ gcode:
             {% if verbose %}
                 RESPOND MSG="Bed mesh measurement..."
             {% endif %}
-            ADAPTIVE_BED_MESH SIZE={FL_SIZE}
+            ADAPTIVE_BED_MESH
         {% else %}
             {% if verbose %}
                 RESPOND MSG="Load bed mesh profile : {BED_MESH_PROFILE}"

--- a/macros/calibration/adaptive_bed_mesh.cfg
+++ b/macros/calibration/adaptive_bed_mesh.cfg
@@ -2,9 +2,10 @@
 ########## ADAPTIVE BED MESH ############
 #########################################
 # Written by Frix_x#0161 #
-# @version: 4.0
+# @version: 5.0
 
 # CHANGELOG:
+#   v5.0: - Uses Klipper adaptive but hack exclude_object to use FL_SIZE
 #   v4.0: - patched and re-simplified the macro to work with latest Klipper changes: zero_reference_position is much more constrained and all the fancy stuff
 #           that was used in the past for homing over the RRI with virtual probe or Z calibration plugin is not possible anymore. Now homing must be done at
 #           fixed zero_reference_poisition and can't be dynamic anymore (but it's also simpler)
@@ -42,201 +43,65 @@
 
 # ===========================================================================================================
 # DO NOT MODIFY THOSE VARIABLES (they are used internaly by the adaptive bed mesh macro)
-[gcode_macro _ADAPTIVE_MESH_VARIABLES]
-variable_ready: False
-variable_do_mesh: False
-variable_do_nominal: False
-variable_mesh_min: 0,0
-variable_mesh_max: 0,0
-variable_probe_count: 0,0
-variable_algo: "bicubic"
-gcode:
-
-
-[gcode_macro COMPUTE_MESH_PARAMETERS]
-description: Compute the mesh parameters and store them for later use
+[gcode_macro ADAPTIVE_BED_MESH]
+description: Perform a bed mesh, but only where and when its needed
 gcode:
     # 1 ----- GET ORIGINAL BEDMESH PARAMS FROM CONFIG ----------------------
-    {% set xMinConf, yMinConf = printer["configfile"].config["bed_mesh"]["mesh_min"].split(',')|map('trim')|map('int') %}
-    {% set xMaxConf, yMaxConf = printer["configfile"].config["bed_mesh"]["mesh_max"].split(',')|map('trim')|map('int') %}
-    {% set xProbeCntConf, yProbeCntConf = printer["configfile"].config["bed_mesh"]["probe_count"].split(',')|map('trim')|map('int') %}
-    {% set algo = printer["configfile"].config["bed_mesh"]["algorithm"]|lower %}
-    {% set xMeshPPS, yMeshPPS = (printer["configfile"].config["bed_mesh"]["mesh_pps"]|default('2,2')).split(',')|map('trim')|map('int') %}
+    {% set _sp = printer["gcode_macro START_PRINT"]|default({"fl_size":[0,0,0,0]}) %}
+    {% set xMinConf, yMinConf = printer.configfile.settings.bed_mesh.mesh_min %}
+    {% set xMaxConf, yMaxConf = printer.configfile.settings.bed_mesh.mesh_max %}
+    {% set xProbeCntConf, yProbeCntConf = printer.configfile.settings.bed_mesh.probe_count %}
+   
+        # compute nominal cell size
+    {% set xCellSize = (xMaxConf - xMinConf ) / (xProbeCntConf - 1) %}
+    {% set yCellSize = (yMaxConf - yMinConf ) / (yProbeCntConf - 1) %}
 
-    {% set margin = params.MARGIN|default(5)|int %} # additional margin to mesh around the first layer
-    {% set force_mesh = params.FORCE_MESH|default(False) %} # force the mesh even if it's a small part (ie. computed less than 3x3)
 
+    {% set margin = params.MARGIN|default(5)|float %} # additional margin to mesh around the first layer
+    {% set force_mesh = params.FORCE_MESH|default(false) %} # force the mesh even if it's a small part (ie. computed less than 3x3)
 
-    # 2 ----- GET FIRST LAYER COORDINATES and SIZE -------------------------------------
-    # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
-    {% set coordinatesFound = false %}
-    {% if params.SIZE is defined and params.SIZE != "0_0_0_0" %}
-        RESPOND MSG="Got a SIZE parameter for the adaptive bed mesh"
-        {% set xMinSpec, yMinSpec, xMaxSpec, yMaxSpec = params.SIZE.split('_')|map('trim')|map('int') %}
-        {% set coordinatesFound = true %}
+    # Retrieve fl_size from param SIZE or START_PRINT
+    {% set fl_size = params.SIZE.split('_')|map('trim')|map('float')|list if params.SIZE else _sp.fl_size  %}
 
-    {% elif printer.exclude_object is defined %}
+    {% set do_mesh = true %}
+    {% set adaptive = 0 %}
+    {% if fl_size != [0,0,0,0] %}
+        {% set adaptive = 1 %}
+        {% set xMinSpec, yMinSpec, xMaxSpec, yMaxSpec = fl_size %}
+
+        # Backup exclude object and create a dummy object for adaptive meshing
         {% if printer.exclude_object.objects %}
-            # Else if SIZE is not defined, we fallback to use the [exclude_object] tags
-            # This method is derived from Kyleisah KAMP repository: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging)
-            RESPOND MSG="No SIZE parameter, using the [exclude_object] tags for the adaptive bed mesh"
-            {% set eo_points = printer.exclude_object.objects|map(attribute='polygon')|sum(start=[]) %}
-            {% set xMinSpec = eo_points|map(attribute=0)|min %}
-            {% set yMinSpec = eo_points|map(attribute=1)|min %}
-            {% set xMaxSpec = eo_points|map(attribute=0)|max %}
-            {% set yMaxSpec = eo_points|map(attribute=1)|max %}
-            {% set coordinatesFound = true %}
-        {% endif %}
-    {% endif %}
+            {% set exclude_object = printer.exclude_object.objects %}
+        {% endif %}  
+        EXCLUDE_OBJECT_DEFINE RESET=1
+        EXCLUDE_OBJECT_DEFINE NAME=fl_size CENTER={ (xMaxSpec-xMinSpec)/2 },{ (xMaxSpec-xMinSpec)/2 } POLYGON=[[{xMinSpec},{yMinSpec}],[{xMinSpec},{yMaxSpec}],[{xMaxSpec},{yMaxSpec}],[{xMaxSpec},{yMinSpec}]]
 
-    {% if not coordinatesFound %}
+        # Disable mesh if print is too small
+        {% if xCellSize >= (xMaxSpec - xMinSpec) and yCellSize >= (yMaxSpec - yMinSpec) %}
+            # Disabel mesh if print area is smaller than a cellsize
+            RESPOND MSG="Bed mesh not needed for very small parts"
+            {% set do_mesh = false %}
+        {% endif %}
+        
+    {% endif %}
+    {% if not adaptive %}
         # If no SIZE parameter and no [exclude_object] tags, then we want to do a nominal bed mesh
         # so nothing to do here...
         RESPOND MSG="No info about the first layer coordinates, doing a nominal bed mesh instead of adaptive"
     {% endif %}
 
-
-    # If the first layer size was correctly retrieved, we can do the adaptive bed mesh logic, else we
-    # fallback to the original and nominal BED_MESH_CALIBRATE function (full bed probing)
-    {% if xMinSpec and yMinSpec and xMaxSpec and yMaxSpec %}
-
-        # 3 ----- APPLY MARGINS ----------------------------------------------
-        # We use min/max function as we want it to be constrained by the original
-        # bedmesh size. This will avoid going outside the machine limits
-        {% set xMin = [xMinConf, (xMinSpec - margin)]|max %}
-        {% set xMax = [xMaxConf, (xMaxSpec + margin)]|min %}
-        {% set yMin = [yMinConf, (yMinSpec - margin)]|max %}
-        {% set yMax = [yMaxConf, (yMaxSpec + margin)]|min %}
-
-        # 4 ----- COMPUTE A NEW PROBE COUNT ----------------------------------
-        # The goal is to have at least the same precision as from the config. So we compute an equivalent number
-        # of probe points on each X/Y dimensions (distance between two points should be the same as in the config)
-        {% set xProbeCnt = ((xMax - xMin) * xProbeCntConf / (xMaxConf - xMinConf))|round(0, 'ceil')|int %}
-        {% set yProbeCnt = ((yMax - yMin) * yProbeCntConf / (yMaxConf - yMinConf))|round(0, 'ceil')|int %}
-
-        # Then, three possibilities :
-        # a) Both dimensions have less than 3 probe points : the bed_mesh is not needed as it's a small print (if not forced).
-        # b) If one of the dimension is less than 3 and the other is greater. The print looks to be elongated and
-        #    need the adaptive bed_mesh : we add probing points to the small direction to reach 3 and be able to do it.
-        # c) If both direction are greater than 3, we need the adaptive bed_mesh and it's ok.
-        # At the end we control (according to Klipper bed_mesh method: "_verify_algorithm") that the computed probe_count is
-        # valid according to the choosen algorithm or change it if needed.
-        {% if xProbeCnt < 3 and yProbeCnt < 3 %}
-            {% if force_mesh %}
-                RESPOND MSG="Bed mesh forced (small part detected): meshing 3x3..."
-                {% set xProbeCnt = 3 %}
-                {% set yProbeCnt = 3 %}
-                {% set algo = "lagrange" %}
-                {% set mesh_min = "%d,%d"|format(xMin, yMin) %}
-                {% set mesh_max = "%d,%d"|format(xMax, yMax) %}
-                {% set probe_count = "%d,%d"|format(xProbeCnt, yProbeCnt) %}
-                RESPOND MSG="Computed mesh parameters: MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} ALGORITHM={algo}"
-                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={True}
-                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_nominal VALUE={False}
-                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_min VALUE='"{mesh_min}"'
-                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_max VALUE='"{mesh_max}"'
-                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=probe_count VALUE='"{probe_count}"'
-                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=algo VALUE='"{algo}"'
-            {% else %}
-                RESPOND MSG="Computed mesh parameters: none, bed mesh not needed for very small parts"
-                SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={False}
-            {% endif %}
-        {% else %}
-            {% set xProbeCnt = [3, xProbeCnt]|max %}
-            {% set yProbeCnt = [3, yProbeCnt]|max %}
-
-            # Check of the probe points and interpolation algorithms according to Klipper code
-            {% if xMeshPPS != 0 or yMeshPPS != 0 %}
-                {% set probeCntMin = [xProbeCnt, yProbeCnt]|min %}
-                {% set probeCntMax = [xProbeCnt, yProbeCnt]|max %}
-                {% if algo == "lagrange" and probeCntMax > 6 %}
-                    # Lagrange interpolation tends to oscillate when using more than 6 samples: swith to bicubic
-                    {% set algo = "bicubic" %}
-                {% endif %}
-                {% if algo == "bicubic" and probeCntMin < 4 %}
-                    {% if probeCntMax > 6 %}
-                        # Impossible case: need to add probe point on the small axis to be >= 4 (we want 5 to keep it odd)
-                        {% if xProbeCnt > yProbeCnt %}
-                            {% set yProbeCnt = 5 %}
-                        {% else %}
-                            {% set xProbeCnt = 5 %}
-                        {% endif %}
-                    {% else %}
-                        # In this case bicubic is not adapted (less than 4 points): switch to lagrange
-                        {% set algo = "lagrange" %}
-                    {% endif %}
-                {% endif %}
-            {% endif %}
-
-            # 5 ----- FORMAT THE PARAMETERS AND SAVE THEM ---------------------------
-            {% set mesh_min = "%d,%d"|format(xMin, yMin) %}
-            {% set mesh_max = "%d,%d"|format(xMax, yMax) %}
-            {% set probe_count = "%d,%d"|format(xProbeCnt, yProbeCnt) %}
-            RESPOND MSG="Computed mesh parameters: MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} ALGORITHM={algo}"
-            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={True}
-            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_nominal VALUE={False}
-            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_min VALUE='"{mesh_min}"'
-            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=mesh_max VALUE='"{mesh_max}"'
-            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=probe_count VALUE='"{probe_count}"'
-            SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=algo VALUE='"{algo}"'
-        {% endif %}
-    {% else %}
-        SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_mesh VALUE={True}
-        SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=do_nominal VALUE={True}
-    {% endif %}
-
-    # Finaly save in the variables that we already computed the values
-    SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=ready VALUE={True}
-
-
-[gcode_macro ADAPTIVE_BED_MESH]
-description: Perform a bed mesh, but only where and when it's needed
-gcode:
-    {% set ready = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].ready %}
-
-    {% if not 'xyz' in printer.toolhead.homed_axes %}
-        { action_raise_error("Must Home printer first!") }
-    {% endif %}
-
-    # If the parameters where computed, we can do the mesh by calling the _DO_ADAPTIVE_MESH
-    {% if ready %}
-        _DO_ADAPTIVE_MESH
-
-    # If the parameters where not computed prior to the ADAPTIVE_BED_MESH call, we call the COMPUTE_MESH_PARAMETERS
-    # macro first and then call the _DO_ADAPTIVE_MESH macro after it
-    {% else %}
-        RESPOND MSG="Adaptive bed mesh: parameters not already computed, automatically calling the COMPUTE_MESH_PARAMETERS macro prior to the mesh"
-        COMPUTE_MESH_PARAMETERS {rawparams}
-        M400 # mandatory to flush the gcode buffer and be sure to use the last computed parameters
-        _DO_ADAPTIVE_MESH
-    {% endif %}
-
-
-[gcode_macro _DO_ADAPTIVE_MESH]
-gcode:
-    # 1 ----- POPULATE BEDMESH PARAMS FROM SAVED VARIABLES ----------------------
-    {% set do_mesh = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].do_mesh %}
-    {% set do_nominal = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].do_nominal %}
-    {% set mesh_min = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].mesh_min %}
-    {% set mesh_max = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].mesh_max %}
-    {% set probe_count = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].probe_count %}
-    {% set algo = printer["gcode_macro _ADAPTIVE_MESH_VARIABLES"].algo %}
-
-    # 2 --------- ADAPTIVE_BED_MESH LOGIC --------------------------------------
-
-    # If it's necessary to do a mesh
-    {% if do_mesh %}
-        # If it's a standard bed_mesh to be done
-        {% if do_nominal %}
-            RESPOND MSG="Adaptive bed mesh: nominal bed mesh"
-            BED_MESH_CALIBRATE
-        {% else %}
-                RESPOND MSG="Adaptive bed mesh: MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} ALGORITHM={algo}"
-                BED_MESH_CALIBRATE MESH_MIN={mesh_min} MESH_MAX={mesh_max} PROBE_COUNT={probe_count} ALGORITHM={algo}
-        {% endif %}
+    {% if do_mesh or force_mesh %}
+        BED_MESH_CALIBRATE ADAPTIVE={adaptive} ADAPTIVE_MARGIN={margin}
     {% else %}
         RESPOND MSG="Adaptive bed mesh: no mesh to be done"
     {% endif %}
 
-    # Set back the 'ready' parameter to false
-    SET_GCODE_VARIABLE MACRO=_ADAPTIVE_MESH_VARIABLES VARIABLE=ready VALUE={False}
+    # Restore exclude Objects
+    EXCLUDE_OBJECT_DEFINE RESET=1
+    {% if exclude_object is defined %}
+        {% for e in exclude_object %}
+            EXCLUDE_OBJECT_DEFINE NAME={e.name} CENTER={e.center|join(',')} POLYGON={e.polygon|string|replace(' ','')}
+        {% endfor %}
+    {% endif %}
+
+

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -4,6 +4,7 @@ gcode:
     # Base macro parameters
     {% set _material = printer["gcode_macro _MATERIAL"].current %}
     {% set _uvars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set _sp = printer["gcode_macro START_PRINT"]%}
     {% set prime_line_length = params.LINE_LENGTH|default(_uvars.prime_line_length)|float %}
     {% set prime_line_purge_length = params.PURGE_LENGTH|default(_material.prime_line_purge_length)|float %}
     {% set prime_line_flowrate = params.FLOWRATE|default(_material.prime_line_flowrate)|float %}
@@ -14,23 +15,9 @@ gcode:
     {% set prime_line_wipe = _uvars.prime_line_wipe|default(False) %}
     {% set prime_line_wipe_length = prime_line_length * 0.8 %}    
 
-    # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
-    {% set coordinatesFound = false %}
-    {% if params.SIZE is defined and params.SIZE != "0_0_0_0" %}
-        {% set xMinSpec, yMinSpec, xMaxSpec, yMaxSpec = params.SIZE.split('_')|map('trim')|map('int') %}
-        {% set coordinatesFound = true %}
-    {% elif printer.exclude_object is defined %}
-        {% if printer.exclude_object.objects %}
-            # Else if SIZE is not defined, we fallback to use the [exclude_object] tags
-            # This method is derived from Kyleisah KAMP repository: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging)
-            {% set eo_points = printer.exclude_object.objects|map(attribute='polygon')|sum(start=[]) %}
-            {% set xMinSpec = eo_points|map(attribute=0)|min %}
-            {% set yMinSpec = eo_points|map(attribute=1)|min %}
-            {% set xMaxSpec = eo_points|map(attribute=0)|max %}
-            {% set yMaxSpec = eo_points|map(attribute=1)|max %}
-            {% set coordinatesFound = true %}
-        {% endif %}
-    {% endif %}
+    # Retrieve fl_size from param SIZE or START_PRINT
+    {% set fl_size = params.SIZE.split('_')|map('trim')|map('float')|list if params.SIZE else _sp.fl_size  %}
+    {% set xMinSpec, yMinSpec, xMaxSpec, yMaxSpec = fl_size %}
 
     # We get the default prime line position parameters
     {% set prime_line_x, prime_line_y = _uvars.prime_line_xy|map('float') %}
@@ -44,7 +31,7 @@ gcode:
     # If first layer coordinates are retrieved and adaptive mode is enabled, then we replace the coordinates to
     # do an adaptive purge while being careful to have the line stay on the bed when the first layer
     # is in an opposite bed quadrant than the prime line initial coordinates (due to mirrored coordinates from center axes)...
-    {% if coordinatesFound and prime_line_adaptive == 1 %}
+    {% if fl_size != [0,0,0,0] and prime_line_adaptive == 1 %}
         {% set prime_line_x = 2*center_x - prime_line_x if prime_line_direction == "X" and ((prime_line_x > center_x and xMaxSpec < center_x) or (prime_line_x < center_x and xMinSpec > center_x))
                                 else prime_line_x %}
         {% set prime_line_y = 2*center_y - prime_line_y if prime_line_direction == "Y" and ((prime_line_y > center_y and yMaxSpec < center_y) or (prime_line_y < center_y and yMinSpec > center_y))


### PR DESCRIPTION
Hello
The macro ADAPTIVE_BED_MESH is a piece of art written by Frix_x that made Klippain what it is today. Few years ago Klipper and Kalico integrate this feature, but somehow some good points of Klippain are missing. Klipper adaptive bed mesh only works with Exclude_object, and always do bed mesh even on small area.

This PR is, at early stage, an attempt to combine Klipper adaptive bed mesh with Klippain print area definition.

The macro ADAPTIVE_BED_MESH creates a dummy object with SIZE parameter or Exclude_object and checks mesh size to exclude small area.
I tested with success with klicky probe, but help is needed to validate with other probe.

Even if it shorten a lot the code of K🍫 ,  I'm not sure this is the right way to proceed. Feel free to close the PR if you prefer.

Thanks,
 

