### PR TITLE
Support sb2040 v3 pro

### DIFF
--- a/config/mcu_definitions/toolhead/Mellow_SB2040_v3_Pro.cfg
+++ b/config/mcu_definitions/toolhead/Mellow_SB2040_v3_Pro.cfg
@@ -19,3 +19,4 @@ aliases:
 
     MCU_LIS2DW_CS=gpio12   , MCU_LIS2DW_SCK=gpio2    , MCU_LIS2DW_MOSI=gpio3    , MCU_LIS2DW_MISO=gpio4    ,
     MCU_MAX31865_CS=gpio17 , MCU_MAX31865_SCK=gpio2  , MCU_MAX31865_MOSI=gpio3  , MCU_MAX31865_MISO=gpio4 ,
+

--- a/user_templates/mcu_defaults/toolhead/Mellow_SB2040_v3_Pro.cfg
+++ b/user_templates/mcu_defaults/toolhead/Mellow_SB2040_v3_Pro.cfg
@@ -1,0 +1,78 @@
+
+#-----------------------------------------------#
+#### Mellow SB2040 v3 Pro MCU definition ########
+#-----------------------------------------------#
+
+[mcu toolhead]
+##--------------------------------------------------------------------
+canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+# If you want to override the wiring of the Mellow SB2040, keep in mind that this
+# board is defined using the "toolhead" name. So you should use "pin: toolhead:PIN_NAME"
+# in your own overrides.cfg files.
+
+[include config/mcu_definitions/toolhead/Mellow_SB2040_v3_Pro.cfg] # Do not remove this line
+[board_pins sb2040_mcu]
+mcu: toolhead
+aliases:
+    E_STEP=MCU_EMOT_STEP , E_DIR=MCU_EMOT_DIR , E_ENABLE=MCU_EMOT_EN , E_TMCUART=MCU_EMOT_UART ,
+
+    X_STOP=MCU_ENDSTOP             ,
+    PROBE_INPUT=MCU_HV_ENDSTOP     ,
+    TOOLHEAD_SENSOR=MCU_5V_ENDSTOP ,
+    EXTRUDER_SENSOR=MCU_FAN2       ,
+
+    E_HEATER=MCU_HEAT , E_TEMPERATURE=MCU_TEMP , CHAMBER_TEMPERATURE=MCU_ONBOARD_NTCK100K ,
+
+    PART_FAN=MCU_FAN0 , E_FAN=MCU_FAN1 ,
+
+    STATUS_NEOPIXEL=MCU_RGB ,
+
+    LIS2DW=MCU_LIS2DW_CS ,
+    SCK=MCU_LIS2DW_SCK , MISO=MCU_LIS2DW_MISO , MOSI=MCU_LIS2DW_MOSI ,
+
+
+#----------------------------------------#
+#     Mellow SB2040 v3 Pro pins remapping    #
+#----------------------------------------#
+
+# These pins overrides are automatically added when you select a CANbus
+# toolhead MCU during the installation process. They should provide a
+# good base to work with. Feel free to adapt to your board if needed!
+
+[extruder]
+step_pin: toolhead:E_STEP
+dir_pin: toolhead:E_DIR
+enable_pin: !toolhead:E_ENABLE
+heater_pin: toolhead:E_HEATER
+sensor_pin: toolhead:E_TEMPERATURE
+#pullup_resistor: 1000               # (1000 for PT1000 with jumper conn，4700-default without jumper)
+## for PT100:
+#sensor_type: MAX31865
+#sensor_pin: toolhead:MCU_MAX31865_CS
+# spi_software_sclk_pin: toolhead:MCU_MAX31865_SCK
+# spi_software_mosi_pin: toolhead:MCU_MAX31865_MOSI
+# spi_software_miso_pin: toolhead:MCU_MAX31865_MISO
+#rtd_reference_r: 430
+
+[probe]
+pin: ^toolhead:PROBE_INPUT
+
+[fan]
+pin: toolhead:PART_FAN
+
+[heater_fan hotend_fan]
+pin: toolhead:E_FAN
+
+## Uncomment the following line if not using sensorless homing
+## and having the X endstop plugged to the toolhead MCU
+# [stepper_x]
+# endstop_pin: ^toolhead:X_STOP
+
+[neopixel status_leds]
+pin: toolhead:STATUS_NEOPIXEL
+
+[tmc2240 extruder]
+uart_pin: toolhead:E_TMCUART
+

--- a/user_templates/mcu_defaults/toolhead/Mellow_SB2040_v3_pro.cfg
+++ b/user_templates/mcu_defaults/toolhead/Mellow_SB2040_v3_pro.cfg
@@ -1,0 +1,21 @@
+# Official documentation https://mellow.klipper.cn/en/docs/ProductDoc/ToolBoard/fly-sb2040/sb2040-pro-v3/wiring
+[board_pins toolhead_manufacturer]
+mcu: toolhead
+aliases:
+    MCU_EMOT_EN=gpio16 , MCU_EMOT_STEP=gpio14 , MCU_EMOT_DIR=gpio13 , MCU_EMOT_UART=gpio15 ,
+
+    MCU_5V_ENDSTOP=gpio18 ,
+    MCU_ENDSTOP=gpio20    ,
+    MCU_HV_ENDSTOP=gpio22 ,
+
+    MCU_FAN0=gpio24 , MCU_FAN1=gpio19 , MCU_FAN2=gpio21 ,
+
+    MCU_TEMP=gpio27 ,
+
+    MCU_HEAT=gpio23 ,
+
+    MCU_RGB=gpio26 ,
+    MCU_PWM0=gpio24 , MCU_PWM1=gpio19 ,
+
+    MCU_LIS2DW_CS=gpio12   , MCU_LIS2DW_SCK=gpio2    , MCU_LIS2DW_MOSI=gpio3    , MCU_LIS2DW_MISO=gpio4    ,
+    MCU_MAX31865_CS=gpio17 , MCU_MAX31865_SCK=gpio2  , MCU_MAX31865_MOSI=gpio3  , MCU_MAX31865_MISO=gpio4 ,


### PR DESCRIPTION
I add Mellow FLY SB2040 PRO V3,
but I set MCU_EMOT_UART like MCU_EMOT_CS.
I don't know how to describe PT100/PT1000 support.
![image](https://github.com/user-attachments/assets/80abcfd2-78a8-4757-b0cd-fba78e58427f)
